### PR TITLE
Issue-42 update unit tests missing the call to parent::setUp()

### DIFF
--- a/test/cases/FormTest.php
+++ b/test/cases/FormTest.php
@@ -16,6 +16,7 @@ class FormTest extends Base {
   protected $form;
 
   public function setUp() {
+    parent::setUp();
     $this->form = $this->getMockForAbstractClass(AbstractBase::class);
   }
 

--- a/test/cases/ShortcodeAuthorizationPolicyTest.php
+++ b/test/cases/ShortcodeAuthorizationPolicyTest.php
@@ -18,6 +18,7 @@ class ShortcodeAuthorizationPolicyTest extends Base {
   private $policy;
 
   public function setUp() {
+    parent::setUp();
     $this->policy = $this->getMockForAbstractClass(
       ShortcodePolicy::class
     );

--- a/test/cases/SiteTest.php
+++ b/test/cases/SiteTest.php
@@ -17,7 +17,7 @@ class SiteTest extends Base {
   const THEME_DIRECTORY = 'wp-content/themes/foo';
 
   public function setUp() {
-    WP_Mock::setUp();
+    parent::setUp();
 
     // do a terrible amount of boilerplate to workaround Timber's decision
     // to put a ton of stuff in the constructor

--- a/test/cases/TemplateAuthorizationPolicyTest.php
+++ b/test/cases/TemplateAuthorizationPolicyTest.php
@@ -16,6 +16,7 @@ class TemplateAuthorizationPolicyTest extends Base {
   private $policy;
 
   public function setUp() {
+    parent::setUp();
     $this->policy = $this->getMockForAbstractClass(
       TemplatePolicy::class
     );

--- a/test/cases/Twig/Filters/FormHelperTest.php
+++ b/test/cases/Twig/Filters/FormHelperTest.php
@@ -13,6 +13,7 @@ use Conifer\Twig\FormHelper;
 
 class FormHelperTest extends Base {
   public function setUp() {
+    parent::setUp();
     $this->wrapper = new FormHelper();
   }
 

--- a/test/cases/UserRoleShortcodePolicyTest.php
+++ b/test/cases/UserRoleShortcodePolicyTest.php
@@ -16,6 +16,7 @@ class UserRoleShortcodeAuthorizationPolicyTest extends Base {
   private $policy;
 
   public function setUp() {
+    parent::setUp();
     $this->policy = new UserRoleShortcodePolicy();
   }
 


### PR DESCRIPTION

**Ticket**: #42

#### Issue

Some Unit tests can't be run indivdually

#### Solution

Make sure all the test case classes call the parent::SetUp() class which bootstraps WP:Mock

#### Impact

We can now run individual unit tests

#### Considerations

We should have a broader conversation about how unit tests are set up in Confier as not all cases are set up the same way
