### PR TITLE
Feature/docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,11 @@ Conifer shares several of Timber's [stated goals](https://github.com/timber/timb
 
 We make every effort to stay out of your way in this regard, to add to and not take away from Timber's powerful features.
 
-## More Helpers
+## Powerful Features
+
+Scan the menu or check out the [Conifer Basics](/getting-started/basics.md) guide for an overview of the powerful features Conifer offers for developing well-architected, object-oriented WordPress code. Here are some of them.
+
+### More Helpers
 
 Simplify your theme with a wealth of utility functions and helpers.
 
@@ -50,16 +54,20 @@ Timber::render('single.twig', $data);
   
   <aside>
   	<h3>Related Posts</h3>
-  	{% for related in post.get_related(3) %}
+  	{% for related in post.get_related_by_category(3) %}
   		<a href="{{ related.link }}">{{ related.title }}</a>
   	{% endfor %}
   </aside>
 </html>	
 ```
 
-## DRY Architecture
+### Easy custom Twig functions/filters
 
-Get more stuff done without so much boilerplate.
+```php
+use MyProject\MyCustomTwigHelper;
+
+$site->add_twig_helper(new MyCustomTwigHelper());
+```
 
 ### AJAX Action API
 
@@ -87,8 +95,6 @@ add_action('wp_ajax_some_action', [MySimpleAjaxHandler::class, 'handle']);
 */
 
 ```
-
-
 
 ### Forms
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -3,7 +3,7 @@
 * [What is Conifer?](/what-is-conifer.md)
 * [Requirements](/requirements.md)
 * [Installation](/installation.md)
-* [Getting Started](/getting-started.md)
+* [Conifer Basics](/basics.md)
 
 ## Features
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -7,10 +7,16 @@
 
 ## Features
 
+* [The Site Class](/site.md)
+
 * [Posts and Post Types](/posts.md)
-* [Admin Helpers](/admin.md)
-* [Authorization](/authorization.md)
+
 * [Forms](/forms.md)
+
+* [Admin Helpers](/admin.md)
+
+* [Authorization](/authorization.md)
+
 
 ## Development
 

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -93,6 +93,15 @@ Conifer boasts a simple [Post API](/features/posts.md) that lets you query and m
 * Group post query results by taxonomy term
 * Configure custom admin filters and columns
 
+### Forms
+
+Conifer comes with an insanely powerful Form API that lets you create and process forms with:
+
+- an extensible, ergonomic OO interface
+- field-specific error states and messaging
+- custom field validations and filters
+- tightly integrated Twig filters for rendering form state
+
 ### Admin Helpers
 
 Conifer's Admin Helpers make working with the WP Admin much simpler:
@@ -107,15 +116,6 @@ Tell WordPress to hide or modify certain content based on the current user:
 * Register a shortcode to let admins control pieces of content to hide based on user role. With a single line of code.
 * Easily define custom shortcodes with arbitrary user authorization logic
 * Redirect away from certain templates if the user lacks specific/arbitrary privileges
-
-### Forms
-
-Conifer comes with an insanely powerful Form API that lets you create and process forms with:
-
-* an extensible, ergonomic OO interface
-* field-specific error states and messaging
-* custom field validations and filters
-* tightly integrated Twig filters for rendering form state
 
 ### Notifiers
 

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -1,0 +1,126 @@
+# Conifer Basics
+
+Getting started with Conifer is easy. Let's dig into the code!
+
+Before diving in, make sure you've [installed](/installation.md) the plugin first, and that your system [meets the requirements](/requirements.md).
+
+After installing and activating Conifer, the first thing you want to do is set up your `Site` instance. In contrast to Timber, Conifer encourages instantiating a `Site` instance and *then* configuring it, rather than throwing site-wide configuration in the constructor. At its most basic, you can call `configure()` with no arguments and it will set you up with some sensible defaults:
+
+```php
+// functions.php
+use Conifer\Site;
+
+// create a new Site instance...
+$site = new Site();
+
+// ...and configure it
+$site->configure();
+```
+
+You can now use the global `$site` variable in your templates.
+
+## Configuring site-wide behavior
+
+Before we explore further, let's say we want to define some custom Twig filters and functions:
+
+```php
+// functions.php
+use Conifer\Site;
+use MyProject\FancyTwigHelper;
+
+// create a new Site instance...
+$site = new Site();
+
+// ...and configure it
+$site->configure(function() {
+  /*
+   * Register custom Twig functions/filters defined in your theme code.
+   * Note that inside this closure, `$this` refers to the site instance!
+   */
+  $this->add_twig_helper(new FancyTwigHelper());
+});
+```
+
+In your WP templates, for example `front-page.php`, stick the home page into Timber/Twig's rendering context with a single call:
+
+```php
+// front-page.php
+use Conifer\Post\FrontPage;
+use Timber\Timber;
+
+// get the Timber context, setting the `post` Twig variable to the FrontPage instance
+$data = $site->get_context_with_post(FrontPage::get());
+
+// render the home page view
+Timber::render('front-page.twig', $data);
+```
+
+The Twig view is standard Timber fare, but note that even with this simplistic approach, you're already set up to use your custom filters and functions defined in your `FancyTwigHelper`:
+
+```twig
+{# front-page.twig #}
+{% extends 'layouts/main.twig' %}
+
+<h1>{{ post.title | my_fancy_twig_filter }}</h1>
+
+<div class="home-page-content {{ my_fancy_post_class_function(post) }}">
+	{{ post.content }}
+</div>
+```
+
+Of course, this is barely scratching the surface of what Conifer can do.
+
+## Diving in
+
+Here's a brief overview of Conifer's biggest features.
+
+### The Site Class
+
+[The `Site` class](/features/site.md) is a concept inherited [from Timber](https://timber.github.io/docs/reference/timber-site/). As in the example above, the Site class `configure()` callback is where your site-wide config code goes in a conventional Conifer-style architecture. This class provides a number of helper methods for:
+
+* setting up sensible site-wide defaults
+* enqueueing scripts and styles
+* easily adding custom Twig functions and filters
+* setting up file "cascades," which tell Timber, Twig, and WordPress where to look for files you tell them to load
+
+### Posts and Post Types
+
+Conifer boasts a simple [Post API](/features/posts.md) that lets you query and manage posts in powerful ways:
+
+* Easily register custom post types
+* Create posts with a single `create()` call
+* Query related posts by any taxonomy
+* Group post query results by taxonomy term
+* Configure custom admin filters and columns
+
+### Admin Helpers
+
+Conifer's Admin Helpers make working with the WP Admin much simpler:
+
+* Display notices to admin users without writing markup
+* Build custom settings pages and sub-pages easily
+
+### Authorization
+
+Tell WordPress to hide or modify certain content based on the current user:
+
+* Register a shortcode to let admins control pieces of content to hide based on user role. With a single line of code.
+* Easily define custom shortcodes with arbitrary user authorization logic
+* Redirect away from certain templates if the user lacks specific/arbitrary privileges
+
+### Forms
+
+Conifer comes with an insanely powerful Form API that lets you create and process forms with:
+
+* an extensible, ergonomic OO interface
+* field-specific error states and messaging
+* custom field validations and filters
+* tightly integrated Twig filters for rendering form state
+
+### Notifiers
+
+Conifer's dead-simple Notifier API lets you send emails to admins and other users at the drop of a hat:
+
+* Email the main site admin with a simple method call
+* Easily send formatted emails to arbitrary addresses
+* Decouple email contents from the destination while reusing code

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,8 +1,0 @@
-# Getting Started with Conifer
-
-So you want to start a WordPress project using Conifer. Great!
-
-Make sure you've [installed](/installation.md) the plugin first,
-and also that your system [meets the requirements](/requirements.md).
-
-...

--- a/docs/posts.md
+++ b/docs/posts.md
@@ -127,7 +127,7 @@ $wall_e->get_field('disposition');
 
 Note that we can mix in the custom `disposition` and `directive` fields with our arguments. Conifer filters the data intelligently, discerning which keys correspond to proper `wp_posts` columns, and which should become meta fields.
 
-## Querying for subclasses
+## Querying for custom post types
 
 Conifer Post classes know how to instantiate themselves in query results. The static `get_all()` method will return an array of whichever subclass of `Post` was called, whether that's `BlogPost`, `Page`, or a CPT:
 

--- a/docs/site.md
+++ b/docs/site.md
@@ -1,0 +1,109 @@
+# The Site Class
+
+As the Conifer Basics page illustrates, the `Site` class is a concept [inherited from Timber](https://timber.github.io/docs/reference/timber-site/) that gives you a single place to put all your site-wide configuration code.
+
+## Basic Usage
+
+The most basic usage involves:
+
+* creating a `Site` instance
+* calling `configure()` on that instance
+
+## Defaults
+
+Calling `configure()` with no arguments will set you up with some sensible defaults:
+
+```php
+// functions.php
+use Conifer\Site;
+
+// create a new Site instance...
+$site = new Site();
+
+// ...and configure it
+$site->configure();
+```
+
+These defaults include:
+
+* Injecting helpful Twig variables into the Timber view context automatically
+* Setting up the Twig "view cascade," a configurable, prioritized list of directories to look in when rendering Twig views
+* Adding the `StringLoader` and `Debug` Twig extensions
+* Registering default Twig helper functions and filters
+* Configuring default integrations with other plugins, such as Yoast SEO (work in progress)
+
+## Simple configuration
+
+Rather than just relying on the defaults, you're likely to need to add some actions or filters. For this, you can pass an anonymous function to `configure()`. We'll refer to this anonymous function as the **configure callback**, or **config callback** for short.
+
+Here's a simple, but realistic, example of what a config callback might look like:
+
+```php
+// functions.php
+use Conifer\Site;
+use MyProject\FancyTwigHelper;
+
+// create a new Site instance
+$site = new Site();
+
+// configure it
+$site->configure(function() {
+  add_action('wp_enqueue_scripts', function() {
+    /*
+     * Enqueue your theme scripts and styles here.
+     * A couple things to note:
+     * - inside this closure, `$this` refers to the site instance
+     * - file paths are relative to the theme directory
+     */
+    $this->enqueue_script('site-common-js', 'dist/common.js');
+    $this->enqueue_style('site-commons-css', 'dist/common.css');
+  });
+  
+  /*
+   * Register custom Twig functions/filters defined in your theme code
+   */
+  $this->add_twig_helper(new FancyTwigHelper());
+    
+  // more custom configuration here...
+});
+```
+
+This approach of passing a function to `conifigure()` has a couple advantages:
+
+- You don't have to define your own `Site` subclass.
+- Wrapping your config code in a closure avoids polluting the global namespace, but also allows it to remain in the familiar functions.php rather than in a random library class, where newcomers to your codebase may not know to look.
+
+### The config callback is totally optional
+
+The config callback-style architecture is pure syntactic sugar: there's no reason you *have* to use it. If you prefer to encapsulate all site-wide behavior directly in a custom `Site` subclass, nothing is stopping you. If you want to preserve the configuration defaults, just make sure you call `parent::configure()` from your subclass:
+
+```php
+// /your/theme/lib/MyProject/Site.php
+namespace MyProject;
+
+use Timber\Site as TimberSite;
+
+class Site extends TimberSite {
+  public function configure() {
+    // configure defaults
+    parent::configure();
+    
+    // your custom config code here...
+  }
+}
+
+// functions.php
+use MyProject\Site;
+
+$site = new Site();
+$site->configure();
+```
+
+## Disabling defaults
+
+If you want to *only* run your custom config callback without funning Conifer's default config code, you can pass `false` as the second argument to `configure()`, which tells Conifer to disable its defaults:
+
+```php
+$site->configure(function() { /* ... */ }, false);
+```
+

--- a/lib/Conifer/Site.php
+++ b/lib/Conifer/Site.php
@@ -63,10 +63,22 @@ class Site extends TimberSite {
   protected $twig_filters = [];
 
   /**
-   * Constructor
+   * Construct a Conifer Site object.
+   *
+   * @example
+   * ```php
+   * use Conifer\Site;
+   *
+   * // non-multisite setup:
+   * $site = new Site();
+   *
+   * // multisite setup:
+   * $site = new Site(1);
+   * ```
+   * @param string|int $identifier the WP site name or ID
    */
-  public function __construct() {
-    parent::__construct();
+  public function __construct($identifier = null) {
+    parent::__construct($identifier);
 
     $this->script_directory_cascade = [get_stylesheet_directory() . '/js/'];
     $this->style_directory_cascade  = [get_stylesheet_directory() . '/'];
@@ -117,6 +129,7 @@ class Site extends TimberSite {
     $this->add_default_twig_helpers();
 
     Integrations\YoastIntegration::demote_metabox();
+    // TODO moar integrations!
   }
 
 


### PR DESCRIPTION
**Ticket**: #32 

#### Issue
Docs are a WiP.

#### Solution

* Better docs for `Site` class
* More details around basic usage
* Describe high-level features on one page

#### Impact / Usage / Conideration

One small tweak to the `Site` constructor to preserve args passed, otherwise just docs. This is an ongoing effort; further improvements forthcoming.

#### Testing

Unit tests are passing; no behavior changes.