### PR TITLE
Feature/form improvements

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,11 @@
+# Glossary
+
+## Timber
+
+Timber is an awesome library plugin for WordPress that implements several killer features, including:
+
+* A powerful object-oriented API for posts, users, terms, menus, and more
+* Twig templates
+* Nice helpers for caching, pagination, and handful of other WordPress features
+
+Timber is Conifer's foundation and is required for all Conifer development.

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -95,7 +95,7 @@ Conifer boasts a simple [Post API](/features/posts.md) that lets you query and m
 
 ### Forms
 
-Conifer comes with an insanely powerful Form API that lets you create and process forms with:
+Conifer comes with an insanely powerful [Form API](/features/forms.md) that lets you create and process forms with:
 
 - an extensible, ergonomic OO interface
 - field-specific error states and messaging
@@ -104,14 +104,14 @@ Conifer comes with an insanely powerful Form API that lets you create and proces
 
 ### Admin Helpers
 
-Conifer's Admin Helpers make working with the WP Admin much simpler:
+Conifer's [Admin Helpers](/features/admin.md) make working with the WP Admin much simpler:
 
 * Display notices to admin users without writing markup
 * Build custom settings pages and sub-pages easily
 
 ### Authorization
 
-Tell WordPress to hide or modify certain content based on the current user:
+Tell WordPress to [hide or modify certain content](/features/authorization.md) based on the current user:
 
 * Register a shortcode to let admins control pieces of content to hide based on user role. With a single line of code.
 * Easily define custom shortcodes with arbitrary user authorization logic
@@ -119,8 +119,9 @@ Tell WordPress to hide or modify certain content based on the current user:
 
 ### Notifiers
 
-Conifer's dead-simple Notifier API lets you send emails to admins and other users at the drop of a hat:
+Conifer's dead-simple [Notifiers](/features/notifiers.md) lets you send emails to admins and other users at the drop of a hat:
 
 * Email the main site admin with a simple method call
 * Easily send formatted emails to arbitrary addresses
 * Decouple email contents from the destination while reusing code
+

--- a/lib/Conifer/Twig/FormHelper.php
+++ b/lib/Conifer/Twig/FormHelper.php
@@ -24,6 +24,8 @@ class FormHelper implements HelperInterface {
       'field_class'        => [$this, 'get_field_class'],
       'error_messages_for' => [$this, 'get_error_messages_for'],
       'err'                => [$this, 'get_error_messages_for'],
+      'checked_attr'       => [$this, 'checked_attr'],
+      'selected_attr'      => [$this, 'selected_attr'],
     ];
   }
 
@@ -69,6 +71,48 @@ class FormHelper implements HelperInterface {
     string $separator = '<br>'
   ) : string {
     return implode($separator, $form->get_error_messages_for($fieldName));
+  }
+
+  /**
+   * Return the `checked` attribute for a given form input, given the
+   * (hydrated) form and the field name, and optionally the value to check
+   * against.
+   *
+   * @param Form $form the Form object containing the field in question
+   * @param string $fieldName the `name` of the field
+   * @param string $value (optional) the value to check against. This is
+   * necessary e.g. for radio inputs, where there's more than one possible
+   * value.
+   * @return string literally `" checked "` if the field (optionally the one
+   * matching `$value`) was checked, or the empty string
+   */
+  public function checked_attr(
+    Form $form,
+    string $fieldName,
+    string $value = null
+  ) : string {
+    return $form->checked($fieldName, $value) ? ' checked ' : '';
+  }
+
+  /**
+   * Return the `selected` attribute for a given form input, given the
+   * (hydrated) form and the field name, and optionally the value to check
+   * against.
+   *
+   * @param Form $form the Form object containing the field in question
+   * @param string $fieldName the `name` of the field
+   * @param string $value (optional) the value to check against. This is
+   * necessary e.g. for radio inputs, where there's more than one possible
+   * value.
+   * @return string literally `" selected "` if the field (optionally the one
+   * matching `$value`) was selected, or the empty string
+   */
+  public function selected_attr(
+    Form $form,
+    string $fieldName,
+    string $value
+  ) : string {
+    return $form->selected($fieldName, $value) ? ' selected ' : '';
   }
 }
 

--- a/test/cases/Twig/Filters/FormHelperTest.php
+++ b/test/cases/Twig/Filters/FormHelperTest.php
@@ -48,4 +48,50 @@ class FormHelperTest extends Base {
       $this->wrapper->get_error_messages_for($form, 'foo', '; ')
     );
   }
+
+  public function test_checked_attr() {
+    $form = $this->setup_form([
+      // field config
+      'my_checkbox' => [],
+    ], [
+      // field config
+      'my_checkbox' => '1',
+    ]);
+
+    $this->assertEquals(
+      ' checked ',
+      $this->wrapper->checked_attr($form, 'my_checkbox', '1')
+    );
+    $this->assertEquals(
+      '',
+      $this->wrapper->checked_attr($form, 'my_checkbox', 'something else')
+    );
+  }
+
+  public function test_selected_attr() {
+    $form = $this->setup_form([
+      // field config
+      'my_select' => [],
+    ], [
+      // field config
+      'my_select' => '1',
+    ]);
+
+    $this->assertEquals(
+      ' selected ',
+      $this->wrapper->selected_attr($form, 'my_select', '1')
+    );
+    $this->assertEquals(
+      '',
+      $this->wrapper->selected_attr($form, 'my_select', 'something else')
+    );
+  }
+
+  protected function setup_form(array $fields, array $values = []) {
+    $form = $this->getMockForAbstractClass(Form::class);
+    $this->setProtectedProperty($form, 'fields', $fields);
+    $form->hydrate($values);
+
+    return $form;
+  }
 }


### PR DESCRIPTION
**Ticket**: none

#### Issue

https://github.com/sitecrafting/conifer/pull/48#issuecomment-419476444

#### Solution

Adds the `checked_attr` and `selected_attr` form filters to `Conifer\Twig\FormHelper`. Also adds a bunch of docs about how to use these and related features of the Form API.

#### Impact

New feature, no breaking changes.

#### Usage Changes

Ditto

#### Considerations

Would be great to get a more comprehensive example in the Form docs.

#### Testing

Includes two new tests, one for each new filter/method.