### PR TITLE
Issue #105 support different asset cache busting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ wp-cli.local.yml
 # documentation
 /docs/_book/
 /docs/reference/*.md
+
+# VS code
+.vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ wp-cli.local.yml
 # documentation
 /docs/_book/
 /docs/reference/*.md
+/docs/node_modules/
 
 # VS code
 .vscode/*

--- a/docs/site.md
+++ b/docs/site.md
@@ -182,6 +182,13 @@ $site->configure(function() {
     $deps    = [],
     $version = true,
     $footer  = true
+  );
+  $this->enqueue_style(
+    $handle  = 'custom-style',
+    $src     = 'custom-style.css',
+    $deps    = [],
+    $version = ['file' => 'custom-style.version'],
+    $footer  = true
 	);
 });
 ```
@@ -189,7 +196,7 @@ $site->configure(function() {
 This looks in the [script cascade and style cascade](#directory-cascades) for `custom.js` and `extra.css`, respectively. The method arguments are almost identical to those of`wp_enqueue_script()` and `wp_enqueue_style()`, with a few exceptions:
 
 * The `$src` argument is evaluated as a path relative to each step in the script/style cascade: that is, Conifer looks first in `js/` or `css/` in the theme by default.
-* The `$version` argument is `true` by default, which tells Conifer to look for a special file called `assets.version` in the theme directory. If the file is found, its contents are passed to `wp_enqueue_*` as the version argument. This can be used as a means of fine-grained [cache-busting](https://css-tricks.com/strategies-for-cache-busting-css/) for your theme assets. If you track bundled assets as part of your theme code in source control and you use a build system such as Webpack, Gulp, or Grunt, just write a content hash or datetime to your theme's `assets.version` file.
+* The `$version` argument is `true` by default, which tells Conifer to look for a special file called `assets.version` in the theme directory. If the file is found, its contents are passed to `wp_enqueue_*` as the version argument. This can be used as a means of fine-grained [cache-busting](https://css-tricks.com/strategies-for-cache-busting-css/) for your theme assets. If you track bundled assets as part of your theme code in source control and you use a build system such as Webpack, Gulp, or Grunt, just write a content hash or datetime to your theme's `assets.version` file. Alternatively, $vesion can be a key/value array. Where the key = "file" and value="filename". This filename will contain a version number for your custom asset. The path is relative to the theme folder.
 
 ## Timber Context helper
 

--- a/lib/Conifer/Site.php
+++ b/lib/Conifer/Site.php
@@ -48,8 +48,9 @@ class Site extends TimberSite {
 
   /**
    * Assets version timestamp, used for cache-busting
-   *
-   * @var string
+   * Array: key=filename, value=timestamp
+   * 
+   * @var array
    */
   protected $assets_version;
 
@@ -152,11 +153,13 @@ class Site extends TimberSite {
    * @param string $scriptHandle the script handle to register
    * @param string $fileName the file to search for in the script cascade path
    * @param array $dependencies an array of registered dependency handles
-   * @param string|bool|null $version the version of the script to append to
+   * @param array|string|bool|null $version the version of the script to append to
    * the URL rendered in the <script> tag. Accepts any valid value of the $ver
    * argument to `wp_register_script`, plus the literal value `true`, which
    * tells Conifer to look for an assets version file to use for cache-busting.
-   * Defaults to `true`.
+   * Pass an array ['file' => 'my-assets-version-text'] to get a custom asset 
+   * file version relative to the theme folder path.
+   * Defaults to `true`. 
    * @param bool $inFooter whether to register this script in the footer. Unlike
    * the same argument to the core `wp_register_script` function, this defaults
    * to `true`.
@@ -168,7 +171,10 @@ class Site extends TimberSite {
     $version = true,
     bool $inFooter = true
   ) {
-    if ($version === true) {
+    if (is_array($version) && isset($version["file"])) {
+      // use defined asset version file for cache-busting in the theme build process
+      $version = $this->get_assets_version($version["file"]);
+    } else if ($version === true) {
       // use automatic any automatic cache-busting in the theme build process
       $version = $this->get_assets_version();
     }
@@ -192,10 +198,12 @@ class Site extends TimberSite {
    * Defaults to the empty string, but is required if the script has not
    * already been registered.
    * @param array $dependencies an array of registered dependency handles
-   * @param string|bool|null $version the version of the script to append to
+   * @param array|string|bool|null $version the version of the script to append to
    * the URL rendered in the <script> tag. Accepts any valid value of the $ver
    * argument to `wp_enqueue_script`, plus the literal value `true`, which
    * tells Conifer to look for an assets version file to use for cache-busting.
+   * Pass an array ['file' => 'my-assets-version-text'] to get a custom asset 
+   * file version relative to the theme folder path.
    * Defaults to `true`.
    * @param bool $inFooter whether to enqueue this script in the footer. Unlike
    * the same argument to the core `wp_enqueue_script` function, this defaults
@@ -208,7 +216,11 @@ class Site extends TimberSite {
     $version = true,
     bool $inFooter = true
   ) {
-    if ($version === true) {
+
+    if (is_array($version) && isset($version["file"])) {
+      // use defined asset version file for cache-busting in the theme build process
+      $version = $this->get_assets_version($version["file"]);
+    } else if ($version === true) {
       // use automatic any automatic cache-busting in the theme build process
       $version = $this->get_assets_version();
     }
@@ -229,10 +241,12 @@ class Site extends TimberSite {
    * @param string $stylesheetHandle the style handle to register
    * @param string $fileName the file to search for in the style cascade path
    * @param array $dependencies an array of registered dependency handles
-   * @param string|bool|null $version the version of the style to append to
+   * @param array|string|bool|null $version the version of the style to append to
    * the URL rendered in the <link> tag. Accepts any valid value of the $ver
    * argument to `wp_register_style`, plus the literal value `true`, which
    * tells Conifer to look for an assets version file to use for cache-busting.
+   * Pass an array ['file' => 'my-assets-version-text'] to get a custom asset 
+   * file version relative to the theme folder path.
    * Defaults to `true`.
    * @param bool $media the media for which this stylesheet has been defined;
    * passed transparently to `wp_register_style`. Defaults to "all" (as does
@@ -245,7 +259,10 @@ class Site extends TimberSite {
     $version = true,
     string $media = 'all'
   ) {
-    if ($version === true) {
+    if (is_array($version) && isset($version["file"])) {
+      // use defined asset version file for cache-busting in the theme build process
+      $version = $this->get_assets_version($version["file"]);
+    } else if ($version === true) {
       // use automatic any automatic cache-busting in the theme build process
       $version = $this->get_assets_version();
     }
@@ -268,10 +285,12 @@ class Site extends TimberSite {
    * Defaults to the empty string, but is required if the style has not
    * already been registered.
    * @param array $dependencies an array of registered dependency handles
-   * @param string|bool|null $version the version of the style to append to
+   * @param array|string|bool|null $version the version of the style to append to
    * the URL rendered in the <link> tag. Accepts any valid value of the $ver
    * argument to `wp_enqueue_style`, plus the literal value `true`, which
    * tells Conifer to look for an assets version file to use for cache-busting.
+   * Pass an array ['file' => 'my-assets-version-text'] to get a custom asset 
+   * file version relative to the theme folder path.
    * Defaults to `true`.
    * @param string $media the media for which this stylesheet has been defined.
    * Passed transparently to `wp_enqueue_style`. Defaults to "all" (as does
@@ -284,7 +303,10 @@ class Site extends TimberSite {
     $version = true,
     string $media = 'all'
   ) {
-    if ($version === true) {
+    if (is_array($version) && isset($version["file"])) {
+      // use defined asset version file for cache-busting in the theme build process
+      $version = $this->get_assets_version($version["file"]);
+    } else if ($version === true) {
       // use automatic any automatic cache-busting in the theme build process
       $version = $this->get_assets_version();
     }
@@ -643,21 +665,42 @@ class Site extends TimberSite {
   }
 
   /**
-   * Get the build-tool-generated hash for global assets
+   * Get the build-tool-generated hash for assets
    *
+   * @param string $filepath Optional filepath to assets.version file
+   * 
    * @return the hash for
    */
-  public function get_assets_version() : string {
-    if (!$this->assets_version && is_readable($this->get_theme_file('assets.version')) ) {
-      // phpcs:ignore WordPress.WP.AlternativeFunctions
-      $contents             = file_get_contents($this->get_theme_file('assets.version'));
-      $this->assets_version = trim($contents);
+  public function get_assets_version($filepath="assets.version") : string {
+
+    $version = "";
+    
+    if (!isset($this->assets_version[$filepath]) && is_readable($this->get_theme_file($filepath)) ) {
+
+      $version = trim(file_get_contents($this->get_theme_file($filepath)));
+
+      if (!is_array($this->assets_version[$filepath])) {
+
+        // start a new array
+        $this->assets_version = [
+          $filepath => $version
+        ];
+
+      } else {
+
+        // add to the array
+        $this->assets_version[$filepath] = $version;
+
+      }
+
+    } else {
+
+      $version = $this->assets_version[$filepath];
+
     }
 
-    $this->assets_version = $this->assets_version ?: '';
+    return $version;
 
-    // Cache the version in this object
-    return $this->assets_version;
   }
 
   /**

--- a/lib/Conifer/Site.php
+++ b/lib/Conifer/Site.php
@@ -667,45 +667,27 @@ class Site extends TimberSite {
   /**
    * Get the build-tool-generated hash for assets
    *
-   * @param string $filepath Optional filepath to assets.version file
-   *
+   * @param string $filepath Optional filepath whose contents will be used
+   * in the cache-busting query string. Defaults to "assets.version"
    * @return the hash for
    */
   public function get_assets_version($filepath = 'assets.version') : string {
 
-    $version = '';
+    $this->assets_version = $this->assets_version ?? [];
 
-    if (!isset($this->assets_version[$filepath]) && is_readable($this->get_theme_file($filepath)) ) {
+    if (
+      !isset($this->assets_version[$filepath])
+      && is_readable($this->get_theme_file($filepath))
+    ) {
 
       // phpcs:ignore WordPress.WP.AlternativeFunctions
       $version = trim(file_get_contents($this->get_theme_file($filepath)));
 
-      if (!is_array($this->assets_version[$filepath])) {
-
-        // start a new array
-        $this->assets_version = [
-          $filepath => $version,
-        ];
-
-      } else {
-
-        // add to the array
-        $this->assets_version[$filepath] = $version;
-
-      }
-    } elseif (isset($this->assets_version[$filepath])) {
-
-      $version = $this->assets_version[$filepath];
-
-    } else {
-
-      // handler for missing file
-      $version = '';
+      $this->assets_version[$filepath] = $version;
 
     }
 
-    return $version;
-
+    return $this->assets_version[$filepath] ?? '';
   }
 
   /**

--- a/lib/Conifer/Site.php
+++ b/lib/Conifer/Site.php
@@ -677,6 +677,7 @@ class Site extends TimberSite {
 
     if (!isset($this->assets_version[$filepath]) && is_readable($this->get_theme_file($filepath)) ) {
 
+      // phpcs:ignore WordPress.WP.AlternativeFunctions
       $version = trim(file_get_contents($this->get_theme_file($filepath)));
 
       if (!is_array($this->assets_version[$filepath])) {

--- a/lib/Conifer/Site.php
+++ b/lib/Conifer/Site.php
@@ -49,7 +49,7 @@ class Site extends TimberSite {
   /**
    * Assets version timestamp, used for cache-busting
    * Array: key=filename, value=timestamp
-   * 
+   *
    * @var array
    */
   protected $assets_version;
@@ -157,9 +157,9 @@ class Site extends TimberSite {
    * the URL rendered in the <script> tag. Accepts any valid value of the $ver
    * argument to `wp_register_script`, plus the literal value `true`, which
    * tells Conifer to look for an assets version file to use for cache-busting.
-   * Pass an array ['file' => 'my-assets-version-text'] to get a custom asset 
+   * Pass an array ['file' => 'my-assets-version-text'] to get a custom asset
    * file version relative to the theme folder path.
-   * Defaults to `true`. 
+   * Defaults to `true`.
    * @param bool $inFooter whether to register this script in the footer. Unlike
    * the same argument to the core `wp_register_script` function, this defaults
    * to `true`.
@@ -171,10 +171,10 @@ class Site extends TimberSite {
     $version = true,
     bool $inFooter = true
   ) {
-    if (is_array($version) && isset($version["file"])) {
+    if (is_array($version) && isset($version['file'])) {
       // use defined asset version file for cache-busting in the theme build process
-      $version = $this->get_assets_version($version["file"]);
-    } else if ($version === true) {
+      $version = $this->get_assets_version($version['file']);
+    } elseif ($version === true) {
       // use automatic any automatic cache-busting in the theme build process
       $version = $this->get_assets_version();
     }
@@ -202,7 +202,7 @@ class Site extends TimberSite {
    * the URL rendered in the <script> tag. Accepts any valid value of the $ver
    * argument to `wp_enqueue_script`, plus the literal value `true`, which
    * tells Conifer to look for an assets version file to use for cache-busting.
-   * Pass an array ['file' => 'my-assets-version-text'] to get a custom asset 
+   * Pass an array ['file' => 'my-assets-version-text'] to get a custom asset
    * file version relative to the theme folder path.
    * Defaults to `true`.
    * @param bool $inFooter whether to enqueue this script in the footer. Unlike
@@ -217,10 +217,10 @@ class Site extends TimberSite {
     bool $inFooter = true
   ) {
 
-    if (is_array($version) && isset($version["file"])) {
+    if (is_array($version) && isset($version['file'])) {
       // use defined asset version file for cache-busting in the theme build process
-      $version = $this->get_assets_version($version["file"]);
-    } else if ($version === true) {
+      $version = $this->get_assets_version($version['file']);
+    } elseif ($version === true) {
       // use automatic any automatic cache-busting in the theme build process
       $version = $this->get_assets_version();
     }
@@ -245,7 +245,7 @@ class Site extends TimberSite {
    * the URL rendered in the <link> tag. Accepts any valid value of the $ver
    * argument to `wp_register_style`, plus the literal value `true`, which
    * tells Conifer to look for an assets version file to use for cache-busting.
-   * Pass an array ['file' => 'my-assets-version-text'] to get a custom asset 
+   * Pass an array ['file' => 'my-assets-version-text'] to get a custom asset
    * file version relative to the theme folder path.
    * Defaults to `true`.
    * @param bool $media the media for which this stylesheet has been defined;
@@ -259,10 +259,10 @@ class Site extends TimberSite {
     $version = true,
     string $media = 'all'
   ) {
-    if (is_array($version) && isset($version["file"])) {
+    if (is_array($version) && isset($version['file'])) {
       // use defined asset version file for cache-busting in the theme build process
-      $version = $this->get_assets_version($version["file"]);
-    } else if ($version === true) {
+      $version = $this->get_assets_version($version['file']);
+    } elseif ($version === true) {
       // use automatic any automatic cache-busting in the theme build process
       $version = $this->get_assets_version();
     }
@@ -289,7 +289,7 @@ class Site extends TimberSite {
    * the URL rendered in the <link> tag. Accepts any valid value of the $ver
    * argument to `wp_enqueue_style`, plus the literal value `true`, which
    * tells Conifer to look for an assets version file to use for cache-busting.
-   * Pass an array ['file' => 'my-assets-version-text'] to get a custom asset 
+   * Pass an array ['file' => 'my-assets-version-text'] to get a custom asset
    * file version relative to the theme folder path.
    * Defaults to `true`.
    * @param string $media the media for which this stylesheet has been defined.
@@ -303,10 +303,10 @@ class Site extends TimberSite {
     $version = true,
     string $media = 'all'
   ) {
-    if (is_array($version) && isset($version["file"])) {
+    if (is_array($version) && isset($version['file'])) {
       // use defined asset version file for cache-busting in the theme build process
-      $version = $this->get_assets_version($version["file"]);
-    } else if ($version === true) {
+      $version = $this->get_assets_version($version['file']);
+    } elseif ($version === true) {
       // use automatic any automatic cache-busting in the theme build process
       $version = $this->get_assets_version();
     }
@@ -668,13 +668,13 @@ class Site extends TimberSite {
    * Get the build-tool-generated hash for assets
    *
    * @param string $filepath Optional filepath to assets.version file
-   * 
+   *
    * @return the hash for
    */
-  public function get_assets_version($filepath="assets.version") : string {
+  public function get_assets_version($filepath = 'assets.version') : string {
 
-    $version = "";
-    
+    $version = '';
+
     if (!isset($this->assets_version[$filepath]) && is_readable($this->get_theme_file($filepath)) ) {
 
       $version = trim(file_get_contents($this->get_theme_file($filepath)));
@@ -683,7 +683,7 @@ class Site extends TimberSite {
 
         // start a new array
         $this->assets_version = [
-          $filepath => $version
+          $filepath => $version,
         ];
 
       } else {
@@ -692,10 +692,14 @@ class Site extends TimberSite {
         $this->assets_version[$filepath] = $version;
 
       }
+    } elseif (isset($this->assets_version[$filepath])) {
+
+      $version = $this->assets_version[$filepath];
 
     } else {
 
-      $version = $this->assets_version[$filepath];
+      // handler for missing file
+      $version = '';
 
     }
 

--- a/test/cases/SiteTest.php
+++ b/test/cases/SiteTest.php
@@ -60,6 +60,7 @@ class SiteTest extends Base {
       'theme-dir' => [
           'test.php'    => 'some text content',
           'assets.version' =>'1',
+          'custom-assets.version' => 'CUSTOM',
       ],
       'an_empty_folder' => [],
     ];
@@ -123,6 +124,46 @@ class SiteTest extends Base {
     $this->assertEquals(
       '1',
       $site->get_assets_version()
+    );
+
+  }
+
+  public function test_get_assets_version_with_arg() {
+
+    $site = new Site();
+
+    // We will set the stylesheet directory to our virtual file system directory
+    WP_Mock::userFunction('get_stylesheet_directory', [
+      'return' => vfsStream::url('root/theme-dir'),
+      'times' => 2,
+    ]);
+
+    // read the file value from our file in the virtual file system directory
+    $this->assertEquals(
+      'CUSTOM',
+      $site->get_assets_version('custom-assets.version')
+    );
+
+  }
+
+  public function test_subsequent_get_assets_version_with() {
+
+    $site = new Site();
+
+    // We will set the stylesheet directory to our virtual file system directory
+    WP_Mock::userFunction('get_stylesheet_directory', [
+      'return' => vfsStream::url('root/theme-dir'),
+      'times' => 4,
+    ]);
+
+    // read the file value from our file in the virtual file system directory
+    $this->assertEquals(
+      'CUSTOM',
+      $site->get_assets_version('custom-assets.version')
+    );
+    $this->assertEquals(
+      '1',
+      $site->get_assets_version('assets.version')
     );
 
   }


### PR DESCRIPTION
**Ticket**: # 
 [Cache busting](https://github.com/sitecrafting/conifer/issues/105) 

#### Issue

As a Conifer user, when registering/enqueuing scripts or styles I want to be able to specify my own cache-busting mechanism or file, instead of using the hard-coded assets.version file path.

#### Solution

<!-- Description of the solution that your changes are introducing -->

#### Impact

Minimal. Custom version numbers are cached to the $this->asset_version property. Converted this from a string to an array.

#### Usage Changes

$version can be an array.

```php
  $this->enqueue_style(
    $handle  = 'custom-style',
    $src     = 'custom-style.css',
    $deps    = [],
    $version = ['file' => 'custom-style.version'],
    $footer  = true
	);
});
```

#### Testing

No tests written. 
Errors with lando sniff and lando unit