### PR TITLE
add a general-purpose capitalize_each Twig filter

### DIFF
--- a/lib/Conifer/Twig/TextHelper.php
+++ b/lib/Conifer/Twig/TextHelper.php
@@ -28,8 +28,9 @@ class TextHelper implements HelperInterface {
    */
   public function get_filters() : array {
     return [
-      'oxford_comma' => [$this, 'oxford_comma'],
-      'pluralize' => [$this, 'pluralize'],
+      'oxford_comma'    => [$this, 'oxford_comma'],
+      'pluralize'       => [$this, 'pluralize'],
+      'capitalize_each' => [$this, 'capitalize_each'],
     ];
   }
 
@@ -86,5 +87,40 @@ class TextHelper implements HelperInterface {
     }
 
     return $list;
+  }
+
+  /**
+   * Capitalize each word in the given $phrase, other than "small" words such
+   * as "a," "the," etc.
+   *
+   * @param string $phrase a string to capitalize each word of
+   * @param array $options an optional array of options including:
+   * - `small_words`: words not to capitalize. Defaults to the normal rules
+   *   of the English language.
+   * - `split_by`: the delimiter for splitting out words when calling
+   *   `explode()`. Defaults to a single space, i.e. `" "`.
+   * @return the capitalized string, e.g. "The Old Man and the Sea"
+   */
+  public function capitalize_each(string $phrase, array $options = []) : string {
+    // @codingStandardsIgnoreStart WordPress.Arrays.ArrayDeclarationSpacing
+    $smallWords = $options['small_words'] ?? [
+      'a', 'and', 'the', 'or', 'of', 'as', 'for', 'but', 'yet', 'so', 'at',
+      'around', 'by', 'after', 'along', 'from', 'on', 'to', 'with', 'without',
+    ];
+
+    $words = explode(($options['split_by'] ?? ' '), $phrase);
+
+    // capitalize each word
+    $capitalizedWords = array_map(
+      function(string $word, int $i) use ($smallWords) : string {
+        // always capitalize the first word; capitalize other "big" words
+        $capitalize = $i === 0 || !in_array(strtolower($word), $smallWords, true);
+        return $capitalize ? ucfirst($word) : lcfirst($word);
+      },
+      $words,
+      array_keys($words)
+    );
+
+    return implode(' ', $capitalizedWords);
   }
 }

--- a/test/cases/TestHelperTest.php
+++ b/test/cases/TestHelperTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Test the Conifer\Site class
+ *
+ * @copyright 2018 SiteCrafting, Inc.
+ * @author    Coby Tamayo <ctamayo@sitecrafting.com>
+ */
+
+namespace ConiferTest;
+
+use Conifer\Twig\TextHelper;
+
+class TextHelperTest extends Base {
+  const THEME_DIRECTORY = 'wp-content/themes/foo';
+
+  public function setUp() {
+    parent::setUp();
+
+    $this->helper = new TextHelper();
+  }
+
+  public function test_oxford_comma() {
+    $this->assertEquals(
+      'one',
+      $this->helper->oxford_comma(['one'])
+    );
+    $this->assertEquals(
+      'one and two',
+      $this->helper->oxford_comma(['one', 'two'])
+    );
+    $this->assertEquals(
+      'one, two, and three',
+      $this->helper->oxford_comma(['one', 'two', 'three'])
+    );
+    $this->assertEquals(
+      'one, two, three, and four',
+      $this->helper->oxford_comma(['one', 'two', 'three', 'four'])
+    );
+  }
+
+  public function test_pluralize() {
+    $this->assertEquals('person', $this->helper->pluralize('person', 1));
+    $this->assertEquals('people', $this->helper->pluralize('person', 2));
+    $this->assertEquals('zebras', $this->helper->pluralize('zebra', 2));
+  }
+
+  public function test_capitalize_each() {
+    $this->assertEquals(
+      'Three Blind Mice',
+      $this->helper->capitalize_each('three blind mice')
+    );
+    $this->assertEquals(
+      'One, Two, or Three',
+      $this->helper->capitalize_each('one, two, or three')
+    );
+    $this->assertEquals(
+      'The Old Man and the Sea',
+      $this->helper->capitalize_each('the old man and the sea')
+    );
+    $this->assertEquals(
+      'Made by SiteCrafting',
+      $this->helper->capitalize_each('Made By SiteCrafting')
+    );
+  }
+}

--- a/test/cases/TestHelperTest.php
+++ b/test/cases/TestHelperTest.php
@@ -2,7 +2,7 @@
 /**
  * Test the Conifer\Site class
  *
- * @copyright 2018 SiteCrafting, Inc.
+ * @copyright 2020 SiteCrafting, Inc.
  * @author    Coby Tamayo <ctamayo@sitecrafting.com>
  */
 


### PR DESCRIPTION
**Ticket**: WSHS-188

#### Issue

As a Conifer user, I want a generic way to _Capitalize Each Word in a Phrase_.

#### Solution

Add a new Twig filter

#### Impact

Only new code; does not affect existing usage.

#### Usage Changes

None.

#### Considerations

Options are provided to make this extensible.

#### Testing

New tests have been added for all `TextHelper` methods.
