### PR TITLE
always return an array from Post::get_all()

### DIFF
--- a/lib/Conifer/Post/Post.php
+++ b/lib/Conifer/Post/Post.php
@@ -228,7 +228,7 @@ abstract class Post extends TimberPost {
       $query['post_type'] = static::_post_type();
     }
 
-    return Timber::get_posts($query, $class);
+    return Timber::get_posts($query, $class) ?: [];
   }
 
   /**


### PR DESCRIPTION
Fix a fatal error when `Timber::get_posts()` returns null