### PR TITLE
Removing deprecated params when getting posts grouped by terms

### DIFF
--- a/lib/Conifer/Post/HasTerms.php
+++ b/lib/Conifer/Post/HasTerms.php
@@ -68,9 +68,7 @@ trait HasTerms {
       // since this may be a special query, we need to check if this term is
       // actually populated/empty.
       $posts = $term->posts(
-        $postQueryArgs,
-        static::_post_type(),
-        static::class
+        $postQueryArgs
       );
       if ($posts) {
         // Group this term with its respective posts.


### PR DESCRIPTION
This tiny PR addresses notices that are generated when trying to pull a list of posts grouped by taxonomy terms. We were still using deprecated parameters that are superseded by class maps in Timber 2. The issue was encountered during the AWB Timber 2 upgrade.