### PR TITLE
twig image helper filter and function to handle retina image path generation

### DIFF
--- a/lib/Conifer/Twig/ImageHelper.php
+++ b/lib/Conifer/Twig/ImageHelper.php
@@ -32,7 +32,7 @@ class ImageHelper implements HelperInterface {
   public function get_filters() : array {
     return [
       'src_to_retina' => [$this, 'src_to_retina'],
-      'src_to_retina_at_mutiplyer' => [$this, 'src_to_retina_at_mutiplyer'],
+      'src_to_retina_at_multiplier' => [$this, 'src_to_retina_at_multiplier'],
     ];
   }
 
@@ -48,15 +48,19 @@ class ImageHelper implements HelperInterface {
   }
 
   /**
-   * Convert the image URL `$src` to its retina equivalent at given multiplyer.
+   * Convert the image URL `$src` to its retina equivalent at given multiplier.
    * Makes sure the file exists.
    *
    * @param `$src` the original src URL
-   * @param `$multiplyer` the multiplyer for the retina image
+   * @param `$multiplier` the multiplier for the retina image
    * @return string the retina src
    */
-  public function src_to_retina_at_mutiplyer(string $src, int $multiplyer = 2) : string {
+  public function src_to_retina_at_multiplier(?string $src, int $multiplier = 2) : string {
     
+    if (!$src) {
+      return '';
+    }
+
     // get the path of the original file
     $file = TimberImageHelper::get_server_location($src);
 
@@ -65,12 +69,12 @@ class ImageHelper implements HelperInterface {
       return '';
     }
 
-    // return base $src if multiplyer less than 2
-    if ($multiplyer < 2) {
+    // return base $src if multiplier less than 2
+    if ($multiplier < 2) {
       return $src;
     }
 
-    $image = preg_replace('~(\.[a-z]+)$~i', "@{$multiplyer}x$1", $src);
+    $image = preg_replace('~(\.[a-z]+)$~i', "@{$multiplier}x$1", $src);
 
     $file = TimberImageHelper::get_server_location($image);
 
@@ -88,15 +92,19 @@ class ImageHelper implements HelperInterface {
    * Will return srcset with files that exist.
    *
    * @param `$src` the original src URL
-  *  @param `$max_multiplyer` the max multiplyer for the set
+  *  @param `$max_multiplier` the max multiplier for the set
    * @return string the retina srcset
    */
-  public function generate_retina_srcset(string $src, int $max_multiplyer = 2) : string {
+  public function generate_retina_srcset(?string $src, int $max_multiplier = 2) : string {
     
+    if (!$src) {
+      return '';
+    }
+
     $set = [];
 
-    // bail if $max_multiplyer < 2. We don't need srcset.
-    if ($max_multiplyer < 2) {
+    // bail if $max_multiplier < 2. We don't need srcset.
+    if ($max_multiplier < 2) {
       return '';
     }
 
@@ -121,7 +129,7 @@ class ImageHelper implements HelperInterface {
         array_push($set, $image . " {$count}x");
       }
       $count++;
-    } while ($count <  $max_multiplyer);
+    } while ($count <  $max_multiplier);
 
     // return srcset or empty string if retina images don't exist
     return count($set)>1 ? 'srcset="'.implode(', ', $set).'"': '';

--- a/lib/Conifer/Twig/ImageHelper.php
+++ b/lib/Conifer/Twig/ImageHelper.php
@@ -5,8 +5,7 @@
 
 namespace Conifer\Twig;
 
-use Timber;
-use TimberImage;
+use Timber\ImageHelper as TimberImageHelper;
 
 /**
  * Twig Wrapper around high-level image functions
@@ -20,7 +19,9 @@ class ImageHelper implements HelperInterface {
    * @return  array an associative array of callback functions, keyed by name
    */
   public function get_functions() : array {
-    return [];
+    return [
+      'generate_retina_srcset' => [$this, 'generate_retina_srcset'],
+    ];
   }
 
   /**
@@ -31,6 +32,7 @@ class ImageHelper implements HelperInterface {
   public function get_filters() : array {
     return [
       'src_to_retina' => [$this, 'src_to_retina'],
+      'src_to_retina_at_mutiplyer' => [$this, 'src_to_retina_at_mutiplyer'],
     ];
   }
 
@@ -43,5 +45,86 @@ class ImageHelper implements HelperInterface {
   public function src_to_retina(string $src) : string {
     // greedily find the last dot
     return preg_replace('~(\.[a-z]+)$~i', '@2x$1', $src);
+  }
+
+  /**
+   * Convert the image URL `$src` to its retina equivalent at given multiplyer.
+   * Makes sure the file exists.
+   *
+   * @param `$src` the original src URL
+   * @param `$multiplyer` the multiplyer for the retina image
+   * @return string the retina src
+   */
+  public function src_to_retina_at_mutiplyer(string $src, int $multiplyer = 2) : string {
+    
+    // get the path of the original file
+    $file = TimberImageHelper::get_server_location($src);
+
+    // bail if the file doesnt exist. No point continuing on.
+    if (!file_exists($file)) {
+      return '';
+    }
+
+    // return base $src if multiplyer less than 2
+    if ($multiplyer < 2) {
+      return $src;
+    }
+
+    $image = preg_replace('~(\.[a-z]+)$~i', "@{$multiplyer}x$1", $src);
+
+    $file = TimberImageHelper::get_server_location($image);
+
+    // return image src if file exists
+    if (file_exists($file)) {
+      return $image;
+    }
+
+    return '';
+
+  }
+
+  /**
+   * Convert the image URL `$src` srcset string up to given size multiplier.
+   * Will return srcset with files that exist.
+   *
+   * @param `$src` the original src URL
+  *  @param `$max_multiplyer` the max multiplyer for the set
+   * @return string the retina srcset
+   */
+  public function generate_retina_srcset(string $src, int $max_multiplyer = 2) : string {
+    
+    $set = [];
+
+    // bail if $max_multiplyer < 2. We don't need srcset.
+    if ($max_multiplyer < 2) {
+      return '';
+    }
+
+    // get the path of the original file
+    $file = TimberImageHelper::get_server_location($src);
+
+    // bail if the file doesnt exist. No point continuing on.
+    if (!file_exists($file)) {
+      return '';
+    }
+
+    // add to the set
+    array_push($set, $src);
+
+    // add additional retna image sizes if they exist
+    $count = 2;
+    do {
+      $image = preg_replace('~(\.[a-z]+)$~i', '@'.$count.'x$1', $src);
+      $file = TimberImageHelper::get_server_location($image);
+
+      if (file_exists($file)) {
+        array_push($set, $image . " {$count}x");
+      }
+      $count++;
+    } while ($count <  $max_multiplyer);
+
+    // return srcset or empty string if retina images don't exist
+    return count($set)>1 ? 'srcset="'.implode(', ', $set).'"': '';
+
   }
 }


### PR DESCRIPTION
**Ticket**: # <!-- ignore this if you're not addressing [specific issue](https://github.com/sitecrafting/conifer/issues) -->

#### Issue

So far, we were relaying on a plugin to provide us with the retina image support for all image tags. This approach proved to be problematic. The functionality provided by some of the plugins used turned no to be reliable.  The retina images were generated correctly but the plugins were not very reliable when it comes to appending necessary html attributes to the `img` tags. 

The proposed change allows developers to have better control over the handling of the retina images. 

#### Solution

The proposed change adds following:
- `src_to_retina_at_mutiplyer` twig filter to help with generating image src path for retina images at requested size multiplier. 
- `generate_retina_srcset` twig function that generates complete `scrset` attribute for a given image up to specified size multiplier.

Both the filter and the function perform check to make sure the retina image version exists prior to returning it or using it to generate `srcset` attribute. 

#### Impact

The change gives developers quick and easy way to add attributes to `img` tags  without relaying on plugins.

#### Usage Changes

Use of the filter and/or the function is optional. 

Example use of the filter:
`<img loading="lazy"{{ class ? ' class="' ~ class ~ '"' }} src="{{ image.src(crop) }}" srcset="{{ image.src(crop) }}, {{ image.src(crop) | src_to_retina_at_mutiplyer(2) }} 2x"alt="{{ image.alt() }}" width="{{ imageWidth }}px" height="{{ imageHeight }}px" />`

Example use of the function:

`<img loading="lazy"{{ class ? ' class="' ~ class ~ '"' }} src="{{ image.src(crop) }}" {{ generate_retina_srcset(image.src(crop), 2) }} alt="{{ image.alt() }}" width="{{ imageWidth }}px" height="{{ imageHeight }}px" />`

