### PR TITLE
Grt 218/docs timber2 compliance

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -48,6 +48,7 @@ export default defineConfig({
                         {text: 'Alerts', link: '/alerts'},
                         {text: 'Authorization', link: '/authorization'},
                         {text: 'Forms', link: '/forms'},
+                        {text: 'Images', link: '/images'},
                         {text: 'Notifiers', link: '/notifiers'},
                         {text: 'Shortcodes', link: '/shortcodes'},
                         {text: 'Twig Helpers', link: '/twig-helpers'},

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -38,6 +38,9 @@ export default defineConfig({
                         {text: 'Basics', link: '/basics'},
                         {text: 'The Site Object', link: '/site'},
                         {text: 'Working with Posts', link: '/posts'},
+                        {text: 'Working with Menus', link: '/menus'},
+                        {text: 'Working with Menu Items', link: '/menu-items'},
+                        {text: 'Working with Images', link: '/images'},
                     ],
                 },
                 {
@@ -48,7 +51,6 @@ export default defineConfig({
                         {text: 'Alerts', link: '/alerts'},
                         {text: 'Authorization', link: '/authorization'},
                         {text: 'Forms', link: '/forms'},
-                        {text: 'Images', link: '/images'},
                         {text: 'Notifiers', link: '/notifiers'},
                         {text: 'Shortcodes', link: '/shortcodes'},
                         {text: 'Twig Helpers', link: '/twig-helpers'},

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ View the docs for [Conifer 1.0](https://coniferplug.in).
 
 ## What is Conifer?
 
-Conifer is a library plugin for creating WordPress plugins and themes using an opinionated object-oriented architecture, built on top of the amazing [Timber](https://timber.github.io/docs/) plugin.
+Conifer is a library plugin for creating WordPress plugins and themes using an opinionated object-oriented architecture, built on top of the amazing [Timber](https://timber.github.io/docs/v2/) plugin.
 
 [Read more about Conifer and its goals](/what-is-conifer.md).
 

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -76,7 +76,7 @@ Here's a brief overview of Conifer's biggest features.
 
 ### The Site Class
 
-[The `Site` class](/site.md) is a concept inherited [from Timber](https://timber.github.io/docs/reference/timber-site/). As in the example above, the Site class `configure()` callback is where your site-wide config code goes in a conventional Conifer-style architecture. This class provides a number of helper methods for:
+[The `Site` class](/site.md) is a concept inherited [from Timber](https://timber.github.io/docs/v2/reference/timber-site/). As in the example above, the Site class `configure()` callback is where your site-wide config code goes in a conventional Conifer-style architecture. This class provides a number of helper methods for:
 
 * setting up sensible site-wide defaults
 * enqueueing scripts and styles

--- a/docs/images.md
+++ b/docs/images.md
@@ -1,28 +1,23 @@
 # Images
 
-Conifer extends the functionality of the [Timber2 Image](https://timber.github.io/docs/v2/reference/timber-image/) class in a few ways. It includes default Image sizes, wrapper functions for getting configured Image sizes, and wrapper functions for getting the height/width/aspect of an Image.
+Conifer extends Timber's [Image](https://timber.github.io/docs/v2/reference/timber-image/) class with helpers for managing registered image sizes and reading image dimensions.
 
 ## Image Sizes
 
-### Default Image sizes
+### Default Image Sizes
 
-Conifer includes the following image sizes by default
-  - `thumbnail`
-    - width: 150px
-    - height: 150px
-  - `medium`    
-    - width: 300px
-    - height: 300px
-  - `medium_large`
-    - width: 768px
-    - height: 768px
-  - `large`
-    - width: 1024px
-    - height: 1024px
+Conifer includes the standard WordPress size names by default:
 
-### Getting Image sizes
+- `thumbnail`
+- `medium`
+- `medium_large`
+- `large`
 
-Conifer includes two functions for fetching image sizes, `get_sizes` and `get_size`
+Conifer reads each size's dimensions from WordPress options (for example, `thumbnail_size_w` and `thumbnail_size_h`), so the actual values reflect your site's Media settings.
+
+### Getting Image Sizes
+
+Use `get_sizes()` to fetch all configured sizes, or `get_size()` to fetch a single size by name.
 
 ```php
 <?php
@@ -31,82 +26,68 @@ declare(strict_types=1);
 
 use Conifer\Post\Image;
 
-// Get all of the configured sizes
+// Get all configured sizes.
 $sizes = Image::get_sizes();
 
-// Get a single configured size
+// Get one configured size.
 $size = Image::get_size('medium');
 ```
 
-### Adding a new Image size
+### Adding a New Image Size
 
-Conifer includes a wrapper around `add_image_size()` to allow you to easily add new sizes for Images
+Use Conifer's wrapper around `add_image_size()` to register custom sizes.
 
 ```php
+
 <?php
 
-declare(strict_types=1);
+use Conifer\Navigation\MenuItem;
+use Conifer\Site;
 
-namespace Project;
-
-use Conifer\Post\Image;
-use Conifer\Site as ConiferSite;
-
-class Site extends ConiferSite
-{
-    public function configure(?callable $userDefinedConfig = null, bool $configureDefaults = true): ConiferSite
-	{
-        //...
-
-        // Add custom image sizes
-        Image::add_size('home-hero', 1440, 790, true);
-		Image::add_size('interior-hero', 1440, 400, true);
-		Image::add_size('interior-fullbleed', 1440, 530, true);
-        // etc..
-    }
-}
+$site = new Site();
+$site->configure(function () {
+    Image::add_size('home-hero', 1440, 790, true);
+    Image::add_size('interior-hero', 1440, 400, true);
+    Image::add_size('interior-fullbleed', 1440, 530, true);
+});
 ```
 
 ## Image dimensions
 
-When working with Images, Conifer includes some utility functions to get the dimensions of your image: `height()`, `width()`, and `aspect()`
+Use `height()`, `width()`, and `aspect()` on a Conifer image instance.
 
 ```php
 <?php
 
 declare(strict_types=1);
 
-use Conifer\Post\Image;
-
-private Image $image;
+use Timber\Timber;
 
 $context = Timber::context();
 
 $cover_image_id = $context['post']->cover_image;
-$image = Timber::get_post($cover_image_id);
+$image = Timber::get_image($cover_image_id);
 
-// Get the height of an Image
-$height = $image->height();
+if ($image) {
+  // Original image dimensions.
+  $height = $image->height();
+  $width = $image->width();
 
-// Or, if your Image is using a custom size
-$height = $image->height( true );
+  // Dimensions for a specific registered size.
+  $custom_height = $image->height('home-hero');
+  $custom_width = $image->width('home-hero');
 
-// Get the width of an Image
-$width = $image->width();
-
-// Or, if your Image is using a custom size
-$width = $image->width( true );
-
-// Get the aspect ratio for an underlying image
-$aspect = $image->aspect();
+  // Underlying file aspect ratio.
+  $aspect = $image->aspect();
+}
 ```
 
-You can also use the same functions in Twig templates
+You can also use these methods directly in Twig templates:
 
 ```twig
-<img 
-    src="{{ image.src }}" 
-    height="{{ image.height }}" 
-    width="{{ image.width }}"
+<img
+  src="{{ image.src }}"
+  height="{{ image.height }}"
+  width="{{ image.width }}"
 />
 ```

--- a/docs/images.md
+++ b/docs/images.md
@@ -41,7 +41,8 @@ Use Conifer's wrapper around `add_image_size()` to register custom sizes.
 
 <?php
 
-use Conifer\Post\Image;
+use Conifer\Post\Image;
+
 use Conifer\Site;
 
 $site = new Site();
@@ -85,6 +86,9 @@ if ($image) {
 You can also use these methods directly in Twig templates:
 
 ```twig
+<!-- Images are not global variables, they must be fetched first -->
+{% set image = get_image($some_id) %}
+
 <img
   src="{{ image.src }}"
   height="{{ image.height }}"

--- a/docs/images.md
+++ b/docs/images.md
@@ -1,0 +1,112 @@
+# Images
+
+Conifer extends the functionality of the [Timber2 Image](https://timber.github.io/docs/v2/reference/timber-image/) class in a few ways. It includes default Image sizes, wrapper functions for getting configured Image sizes, and wrapper functions for getting the height/width/aspect of an Image.
+
+## Image Sizes
+
+### Default Image sizes
+
+Conifer includes the following image sizes by default
+  - `thumbnail`
+    - width: 150px
+    - height: 150px
+  - `medium`    
+    - width: 300px
+    - height: 300px
+  - `medium_large`
+    - width: 768px
+    - height: 768px
+  - `large`
+    - width: 1024px
+    - height: 1024px
+
+### Getting Image sizes
+
+Conifer includes two functions for fetching image sizes, `get_sizes` and `get_size`
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Conifer\Post\Image;
+
+// Get all of the configured sizes
+$sizes = Image::get_sizes();
+
+// Get a single configured size
+$size = Image::get_size('medium');
+```
+
+### Adding a new Image size
+
+Conifer includes a wrapper around `add_image_size()` to allow you to easily add new sizes for Images
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Project;
+
+use Conifer\Post\Image;
+use Conifer\Site as ConiferSite;
+
+class Site extends ConiferSite
+{
+    public function configure(?callable $userDefinedConfig = null, bool $configureDefaults = true): ConiferSite
+	{
+        //...
+
+        // Add custom image sizes
+        Image::add_size('home-hero', 1440, 790, true);
+		Image::add_size('interior-hero', 1440, 400, true);
+		Image::add_size('interior-fullbleed', 1440, 530, true);
+        // etc..
+    }
+}
+```
+
+## Image dimensions
+
+When working with Images, Conifer includes some utility functions to get the dimensions of your image: `height()`, `width()`, and `aspect()`
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Conifer\Post\Image;
+
+private Image $image;
+
+$context = Timber::context();
+
+$cover_image_id = $context['post']->cover_image;
+$image = Timber::get_post($cover_image_id);
+
+// Get the height of an Image
+$height = $image->height();
+
+// Or, if your Image is using a custom size
+$height = $image->height( true );
+
+// Get the width of an Image
+$width = $image->width();
+
+// Or, if your Image is using a custom size
+$width = $image->width( true );
+
+// Get the aspect ratio for an underlying image
+$aspect = $image->aspect();
+```
+
+You can also use the same functions in Twig templates
+
+```twig
+<img 
+    src="{{ image.src }}" 
+    height="{{ image.height }}" 
+    width="{{ image.width }}"
+/>
+```

--- a/docs/images.md
+++ b/docs/images.md
@@ -41,7 +41,7 @@ Use Conifer's wrapper around `add_image_size()` to register custom sizes.
 
 <?php
 
-use Conifer\Navigation\MenuItem;
+use Conifer\Post\Image;
 use Conifer\Site;
 
 $site = new Site();

--- a/docs/menu-items.md
+++ b/docs/menu-items.md
@@ -1,66 +1,54 @@
 # MenuItem
 
-Conifer extends the functionality of the [MenuItem](https://timber.github.io/docs/v2/reference/timber-menuitem/) class. These functions are helpful when rendering large side navigation menus with a complicated hierarchy.
+Conifer extends Timber's [MenuItem](https://timber.github.io/docs/v2/reference/timber-menuitem/) class with helpers for rendering hierarchical navigation.
 
 ## Registering MenuItem
 
-Like in Timber, you must add the MenuItem to the classmap in order for Timber to know which class to use when calling `Timber::get_menu()`
+As with Timber, register your custom MenuItem class in the class map so Timber knows which class to use when fetching MenuItems
 
 ```php
-// In functions.php
-<?php>
+<?php
 
-use Conifer\Site;
-use Conifer\Navigation\Menu;
 use Conifer\Navigation\MenuItem;
+use Conifer\Site;
 
 $site = new Site();
-$site->configure(function() {
-    //... rest of configure function
-
-    // Add MenuItem to classmap
-    add_filter('timber/menuitem/classmap', function ($classmap) {
-        $custom_classmap = [
+$site->configure(function () {
+    add_filter('timber/menuitem/classmap', function (array $classmap): array {
+        return array_merge($classmap, [
             'primary' => MenuItem::class,
-        ];
-    
-        return array_merge($classmap, $custom_classmap);
+            'footer'  => MenuItem::class,
+        ]);
     });
+});
 ```
 
-## Determining current post
+## Determining the current post
 
-Conifer includes a helper function `points_to_current_post_or_ancestor()` which determines if a MenuItem points to the current post, or an ancestor of the current post
+Use `points_to_current_post_or_ancestor()` to determine whether a menu item points to the current post or one of its ancestors.
 
 ```twig
-{% if menuItem.points_to_current_post_or_ancestor %}
-    <p>This MenuItem points to the current post, or an ancestor of the current post!</p>
+{% if item.points_to_current_post_or_ancestor %}
+    <p>This item points to the current post (or one of its ancestors).</p>
 {% endif %}
 ```
 
-## Children
+## Rendering children
 
-Conifer includes two utility functions for rendering child MenuItems, `has_children()` and `display_children()`
+Conifer provides two related helpers:
+
+- `has_children()` checks whether the item has child menu items.
+- `display_children()` returns `true` only when the item has children and points to the current post (or an ancestor).
 
 ```twig
-<!-- Check if this MenuItem has child MenuItems -->
-{% if menuItem.has_children %}
-    <!-- This MenuItem has children. You can also check if those child MenuItems should be rendered -->
-
-    <!-- Check if those menu items should be rendered -->
-    {% if menuItem.display_children %}
-        <!-- Render child MenuItems -->
-        {% for child in menuItem.children %}
+{% if item.has_children %}
+    {% if item.display_children %}
+        {% for child in item.children %}
             <li class="nav-child-item">
-                <a
-                    class="nav-child-link"
-                    href="{{ child.link }}"
-                >{{ child.title }}</a>
+                <a class="nav-child-link" href="{{ child.link }}">{{ child.title }}</a>
             </li>
         {% endfor %}
     {% endif %}
-{% else %}
-    <!-- This MenuItem does not have any children -->
 {% endif %}
 ```
 

--- a/docs/menu-items.md
+++ b/docs/menu-items.md
@@ -1,0 +1,66 @@
+# MenuItem
+
+Conifer extends the functionality of the [MenuItem](https://timber.github.io/docs/v2/reference/timber-menuitem/) class. These functions are helpful when rendering large side navigation menus with a complicated hierarchy.
+
+## Registering MenuItem
+
+Like in Timber, you must add the MenuItem to the classmap in order for Timber to know which class to use when calling `Timber::get_menu()`
+
+```php
+// In functions.php
+<?php>
+
+use Conifer\Site;
+use Conifer\Navigation\Menu;
+use Conifer\Navigation\MenuItem;
+
+$site = new Site();
+$site->configure(function() {
+    //... rest of configure function
+
+    // Add MenuItem to classmap
+    add_filter('timber/menuitem/classmap', function ($classmap) {
+        $custom_classmap = [
+            'primary' => MenuItem::class,
+        ];
+    
+        return array_merge($classmap, $custom_classmap);
+    });
+```
+
+## Determining current post
+
+Conifer includes a helper function `points_to_current_post_or_ancestor()` which determines if a MenuItem points to the current post, or an ancestor of the current post
+
+```twig
+{% if menuItem.points_to_current_post_or_ancestor %}
+    <p>This MenuItem points to the current post, or an ancestor of the current post!</p>
+{% endif %}
+```
+
+## Children
+
+Conifer includes two utility functions for rendering child MenuItems, `has_children()` and `display_children()`
+
+```twig
+<!-- Check if this MenuItem has child MenuItems -->
+{% if menuItem.has_children %}
+    <!-- This MenuItem has children. You can also check if those child MenuItems should be rendered -->
+
+    <!-- Check if those menu items should be rendered -->
+    {% if menuItem.display_children %}
+        <!-- Render child MenuItems -->
+        {% for child in menuItem.children %}
+            <li class="nav-child-item">
+                <a
+                    class="nav-child-link"
+                    href="{{ child.link }}"
+                >{{ child.title }}</a>
+            </li>
+        {% endfor %}
+    {% endif %}
+{% else %}
+    <!-- This MenuItem does not have any children -->
+{% endif %}
+```
+

--- a/docs/menus.md
+++ b/docs/menus.md
@@ -1,69 +1,60 @@
 # Menu
 
-Conifer extends the functionality of the [Menu](https://timber.github.io/docs/v2/reference/timber-menu/) class.
+Conifer extends Timber's [Menu](https://timber.github.io/docs/v2/reference/timber-menu/) class.
 
 ## Registering Menu
 
-Like in Timber, you must add the Menu to the classmap before it can be added to the Site's context. Additionally, you must also register the nav menu and add it to the Site's context.
+Before using Conifer's `Menu` class, register it in Timber's menu class map. In most cases, you will also register your menu locations and add menu instances to the Timber context.
 
 ```php
-// In functions.php
-<?php>
+<?php
 
-use Conifer\Site;
 use Conifer\Navigation\Menu;
-use Conifer\Navigation\MenuItem;
+use Conifer\Site;
+use Timber\Timber;
 
 $site = new Site();
-$site->configure(function() {
-    //... rest of configure function
-
-    // Add Menu to classmap
-    add_filter('timber/menu/classmap', function ($classmap) {
-        $custom_classmap = [
+$site->configure(function () {
+    add_filter('timber/menu/classmap', function (array $classmap): array {
+        return array_merge($classmap, [
             'primary' => Menu::class,
-            'footer' => Menu::class,
-        ];
-        return array_merge($classmap, $custom_classmap);
-    }, 10);
+            'footer'  => Menu::class,
+        ]);
+    });
 
-    // Register navigation
     register_nav_menus([
-        'primary' => 'Main Navigation', // main page/nav structure
-        'footer' => 'Footer Navigation', // footer nav
+        'primary' => 'Main Navigation',
+        'footer'  => 'Footer Navigation',
     ]);
 
-    add_filter('timber/context', function(array $context) : array {
-
-        $context['primary_menu']    = Timber::get_menu('primary');
-        $context['footer_menu']    = Timber::get_menu('footer');
+    add_filter('timber/context', function (array $context): array {
+        $context['primary_menu'] = Timber::get_menu('primary');
+        $context['footer_menu']  = Timber::get_menu('footer');
 
         return $context;
     });
-
-    //... remainder of configure function
+});
 ```
 
-After your menu is registered, you can use it in your Twig files and it will automatically be fetched from the context
+After registration, these menu variables are available in Twig.
 
 ```twig
-<!-- \app\themes\{your_theme}\views\parials\blocks\header.twig -->
-
-<!-- primary_menu is available to use because it was registered in functions.php -->
+{# views/partials/blocks/header.twig #}
 {% include 'partials/blocks/nav.twig' with { menu: primary_menu } only %}
 ```
 
-## Getting the top level MenuItem
+## Getting the top-level MenuItem
 
-Conifer adds a utility function to get the top level MenuItem when viewing a Post, `get_current_top_level_item()`
+Use `get_current_top_level_item()` to retrieve the top-level menu item that points to the current post (or to an ancestor of the current post).
 
 ```twig
+{% set top_level_item = menu.get_current_top_level_item() %}
 
-{% set topLevelMenuItem = menu.get_current_top_level_item() %}
+{% if top_level_item %}
+    <a href="{{ top_level_item.link }}">{{ top_level_item.title }}</a>
 
-<a href="{{ menu.get_current_top_level_item().get_path }}">{{ menu.get_current_top_level_item().title }}</a>
-
-{% for item in menu.get_current_top_level_item().get_children() %}
-    <!-- Render children MenuItems -->
-{% endfor %}
+    {% for item in top_level_item.children %}
+        {# Render child menu items #}
+    {% endfor %}
+{% endif %}
 ```

--- a/docs/menus.md
+++ b/docs/menus.md
@@ -1,0 +1,69 @@
+# Menu
+
+Conifer extends the functionality of the [Menu](https://timber.github.io/docs/v2/reference/timber-menu/) class.
+
+## Registering Menu
+
+Like in Timber, you must add the Menu to the classmap before it can be added to the Site's context. Additionally, you must also register the nav menu and add it to the Site's context.
+
+```php
+// In functions.php
+<?php>
+
+use Conifer\Site;
+use Conifer\Navigation\Menu;
+use Conifer\Navigation\MenuItem;
+
+$site = new Site();
+$site->configure(function() {
+    //... rest of configure function
+
+    // Add Menu to classmap
+    add_filter('timber/menu/classmap', function ($classmap) {
+        $custom_classmap = [
+            'primary' => Menu::class,
+            'footer' => Menu::class,
+        ];
+        return array_merge($classmap, $custom_classmap);
+    }, 10);
+
+    // Register navigation
+    register_nav_menus([
+        'primary' => 'Main Navigation', // main page/nav structure
+        'footer' => 'Footer Navigation', // footer nav
+    ]);
+
+    add_filter('timber/context', function(array $context) : array {
+
+        $context['primary_menu']    = Timber::get_menu('primary');
+        $context['footer_menu']    = Timber::get_menu('footer');
+
+        return $context;
+    });
+
+    //... remainder of configure function
+```
+
+After your menu is registered, you can use it in your Twig files and it will automatically be fetched from the context
+
+```twig
+<!-- \app\themes\{your_theme}\views\parials\blocks\header.twig -->
+
+<!-- primary_menu is available to use because it was registered in functions.php -->
+{% include 'partials/blocks/nav.twig' with { menu: primary_menu } only %}
+```
+
+## Getting the top level MenuItem
+
+Conifer adds a utility function to get the top level MenuItem when viewing a Post, `get_current_top_level_item()`
+
+```twig
+
+{% set topLevelMenuItem = menu.get_current_top_level_item() %}
+
+<a href="{{ menu.get_current_top_level_item().get_path }}">{{ menu.get_current_top_level_item().title }}</a>
+
+{% for item in menu.get_current_top_level_item().get_children() %}
+    <!-- Render children MenuItems -->
+{% endfor %}
+```

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2,7 +2,7 @@
 
 Conifer requires the following software:
 
-* PHP 7.0+
-* WordPress 4.9.x
-* [Timber](https://timber.github.io/docs/)
+* PHP 8.1+
+* WordPress 6.5.x
+* [Timber 2](https://timber.github.io/docs/v2/)
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -4,5 +4,4 @@ Conifer requires the following software:
 
 * PHP 8.1+
 * WordPress 6.5.x
-* [Timber 2](https://timber.github.io/docs/v2/)
 

--- a/docs/site.md
+++ b/docs/site.md
@@ -1,6 +1,6 @@
 # The Site Class
 
-As the Conifer Basics page illustrates, the `Site` class is a concept [inherited from Timber](https://timber.github.io/docs/reference/timber-site/) that gives you a single place to put all your site-wide configuration code.
+As the Conifer Basics page illustrates, the `Site` class is a concept [inherited from Timber](https://timber.github.io/docs/v2/reference/timber-site/) that gives you a single place to put all your site-wide configuration code.
 
 ## Basic Usage
 

--- a/docs/twig-helpers.md
+++ b/docs/twig-helpers.md
@@ -77,7 +77,7 @@ Now, instantiate and register your helper:
 $site->add_twig_helper(new ThemeTwigHelper());
 ```
 
-The text being filtered is always the first argument to the callback, just like when you register a callback directly with `Twig_SimpleFilter`.
+The text being filtered is always the first argument to the callback, just like when you register a callback directly with `Twig\TwigFilter`.
 
 Note that in this example, we didn't define any Twig functions, but to keep PHP happy, we still have to implement both public methods, where one simply returns an empty array.
 


### PR DESCRIPTION
**Ticket**: # https://sitecrafting.atlassian.net/browse/GRT-218

#### Issue

The Conifer documentation has not been updated for Timber2 compliance. Additionally, it is missing important sections for Image handling and Menu/MenuItem functionality.

#### Solution

This PR updates the Conifer documentation to be Timber2 compliant, and adds important missing sections.
