### PR TITLE
adding tests to cover remainder of core functionality

### DIFF
--- a/test/unit/Admin/AdminNoticeTest.php
+++ b/test/unit/Admin/AdminNoticeTest.php
@@ -156,4 +156,141 @@ class AdminNoticeTest extends Base
   {
     WP_Mock::expectActionAdded('admin_notices', Functions::type('callable'));
   }
+
+  // ---------------------------------------------------------------------------
+  // flash() / flash_error() / flash_warning() / flash_info() / flash_success()
+  // ---------------------------------------------------------------------------
+
+  public function test_flash_error_adds_error_class_and_registers_admin_notices_hook()
+  {
+    $notice = new Notice('Something went wrong');
+    WP_Mock::expectActionAdded('admin_notices', Functions::type('callable'));
+
+    $notice->flash_error();
+
+    $this->assertTrue($notice->has_class('notice-error'), 'flash_error() should add notice-error class');
+  }
+
+  public function test_flash_warning_adds_warning_class_and_registers_admin_notices_hook()
+  {
+    $notice = new Notice('Heads up');
+    WP_Mock::expectActionAdded('admin_notices', Functions::type('callable'));
+
+    $notice->flash_warning();
+
+    $this->assertTrue($notice->has_class('notice-warning'), 'flash_warning() should add notice-warning class');
+  }
+
+  public function test_flash_info_adds_info_class_and_registers_admin_notices_hook()
+  {
+    $notice = new Notice('For your information');
+    WP_Mock::expectActionAdded('admin_notices', Functions::type('callable'));
+
+    $notice->flash_info();
+
+    $this->assertTrue($notice->has_class('notice-info'), 'flash_info() should add notice-info class');
+  }
+
+  public function test_flash_success_adds_success_class_and_registers_admin_notices_hook()
+  {
+    $notice = new Notice('All done');
+    WP_Mock::expectActionAdded('admin_notices', Functions::type('callable'));
+
+    $notice->flash_success();
+
+    $this->assertTrue($notice->has_class('notice-success'), 'flash_success() should add notice-success class');
+  }
+
+  public function test_flash_writes_class_and_message_to_session_when_closure_fires()
+  {
+    // flash() schedules a closure via add_action('admin_notices'). This test
+    // captures and invokes that closure directly to verify the session payload.
+    $_SESSION[Notice::FLASH_SESSION_KEY] = [];
+
+    WP_Mock::expectActionAdded('admin_notices', Functions::type('callable'));
+
+    $double = new NoticeFlashCapture('A flash message', 'notice-success');
+    $double->flash();
+    $double->invokeCapturedClosure();
+
+    $written = $_SESSION[Notice::FLASH_SESSION_KEY];
+    $this->assertCount(1, $written);
+    $this->assertSame('A flash message', $written[0]['message']);
+    $this->assertStringContainsString('notice-success', $written[0]['class']);
+  }
+
+  // ---------------------------------------------------------------------------
+  // display_flash_notices()
+  // ---------------------------------------------------------------------------
+
+  public function test_display_flash_notices_displays_notices_and_clears_session_when_enabled()
+  {
+    $_SESSION[Notice::FLASH_SESSION_KEY] = [
+      ['class' => 'notice notice-success', 'message' => 'Saved'],
+    ];
+
+    // Notice::display() registers an admin_notices action for each notice shown
+    WP_Mock::expectActionAdded('admin_notices', Functions::type('callable'));
+
+    // Flash notices are already enabled in setUp()
+    Notice::display_flash_notices();
+
+    $this->assertEmpty(
+      $_SESSION[Notice::FLASH_SESSION_KEY],
+      'Session should be emptied after display_flash_notices() runs'
+    );
+  }
+
+  public function test_display_flash_notices_is_noop_when_flash_is_disabled()
+  {
+    $_SESSION[Notice::FLASH_SESSION_KEY] = [
+      ['class' => 'notice notice-error', 'message' => 'Should not display'],
+    ];
+
+    Notice::disable_flash_notices();
+    Notice::display_flash_notices();
+
+    $this->assertCount(
+      1,
+      $_SESSION[Notice::FLASH_SESSION_KEY],
+      'Session must be untouched when flash notices are disabled'
+    );
+  }
+}
+
+/**
+ * Test double that captures the closure registered by flash() so it can be
+ * invoked synchronously within a test — without requiring WP action dispatch.
+ *
+ * The closure logic mirrors Notice::flash() exactly, using inherited access
+ * to the protected $message property and the concrete get_class() method.
+ */
+class NoticeFlashCapture extends Notice
+{
+  private ?\Closure $capturedClosure = null;
+
+  public function flash(): void
+  {
+    // Capture the values that the real closure would close over
+    $class   = $this->get_class();
+    $message = $this->message;
+
+    $this->capturedClosure = static function () use ($class, $message) {
+      $_SESSION[static::FLASH_SESSION_KEY]   = $_SESSION[static::FLASH_SESSION_KEY] ?? [];
+      $_SESSION[static::FLASH_SESSION_KEY][] = [
+        'class'   => $class,
+        'message' => $message,
+      ];
+    };
+
+    // Satisfy WP_Mock::expectActionAdded('admin_notices', ...) expectations
+    add_action('admin_notices', $this->capturedClosure);
+  }
+
+  public function invokeCapturedClosure(): void
+  {
+    if ($this->capturedClosure !== null) {
+      ($this->capturedClosure)();
+    }
+  }
 }

--- a/test/unit/AjaxHandler/AjaxHandlerTest.php
+++ b/test/unit/AjaxHandler/AjaxHandlerTest.php
@@ -113,9 +113,11 @@ class AjaxHandlerTest extends Base
     $_COOKIE     = ['session_token' => 'abc123'];
     AjaxHandlerInspectable::$lastResponse = null;
 
-    AjaxHandlerInspectable::handle(['action' => 'inspect']);
-
-    $_COOKIE = $savedCookie;
+    try {
+      AjaxHandlerInspectable::handle(['action' => 'inspect']);
+    } finally {
+      $_COOKIE = $savedCookie;
+    }
 
     $response = AjaxHandlerInspectable::$lastResponse;
     $this->assertIsArray($response);
@@ -128,9 +130,11 @@ class AjaxHandlerTest extends Base
     $_REQUEST     = ['action' => 'from_request', 'key' => 'val'];
     AjaxHandlerInspectable::$lastResponse = null;
 
-    AjaxHandlerInspectable::handle();
-
-    $_REQUEST = $savedRequest;
+    try {
+      AjaxHandlerInspectable::handle();
+    } finally {
+      $_REQUEST = $savedRequest;
+    }
 
     $response = AjaxHandlerInspectable::$lastResponse;
     $this->assertIsArray($response, 'handle() with no args should populate $lastResponse from $_REQUEST');
@@ -144,9 +148,11 @@ class AjaxHandlerTest extends Base
     $_POST     = ['action' => 'post_action', 'data' => 'posted'];
     AjaxHandlerInspectable::$lastResponse = null;
 
-    AjaxHandlerInspectable::handle_post();
-
-    $_POST = $savedPost;
+    try {
+      AjaxHandlerInspectable::handle_post();
+    } finally {
+      $_POST = $savedPost;
+    }
 
     $response = AjaxHandlerInspectable::$lastResponse;
     $this->assertIsArray($response);

--- a/test/unit/AjaxHandler/AjaxHandlerTest.php
+++ b/test/unit/AjaxHandler/AjaxHandlerTest.php
@@ -79,4 +79,203 @@ class AjaxHandlerTest extends Base
     // with each request to be considered valid
     return ['action' => 'best_band'];
   }
+
+  // ---------------------------------------------------------------------------
+  // Constructor
+  // ---------------------------------------------------------------------------
+
+  public function test_constructor_throws_when_action_key_is_absent_from_request()
+  {
+    $this->expectException(\LogicException::class);
+
+    new AjaxHandlerInspectable(['data' => 'no_action_here']);
+  }
+
+  // ---------------------------------------------------------------------------
+  // handle() / handle_post() / handle_get()
+  // ---------------------------------------------------------------------------
+
+  public function test_handle_creates_handler_executes_and_stores_response()
+  {
+    AjaxHandlerInspectable::$lastResponse = null;
+
+    AjaxHandlerInspectable::handle(['action' => 'inspect', 'foo' => 'bar']);
+
+    $response = AjaxHandlerInspectable::$lastResponse;
+    $this->assertIsArray($response);
+    $this->assertSame('inspect', $response['action']);
+    $this->assertSame(['action' => 'inspect', 'foo' => 'bar'], $response['params']);
+  }
+
+  public function test_handle_passes_cookie_superglobal_to_handler()
+  {
+    $savedCookie = $_COOKIE;
+    $_COOKIE     = ['session_token' => 'abc123'];
+    AjaxHandlerInspectable::$lastResponse = null;
+
+    AjaxHandlerInspectable::handle(['action' => 'inspect']);
+
+    $_COOKIE = $savedCookie;
+
+    $response = AjaxHandlerInspectable::$lastResponse;
+    $this->assertIsArray($response);
+    $this->assertSame(['session_token' => 'abc123'], $response['cookies']);
+  }
+
+  public function test_handle_falls_back_to_request_superglobal_when_no_data_passed()
+  {
+    $savedRequest = $_REQUEST;
+    $_REQUEST     = ['action' => 'from_request', 'key' => 'val'];
+    AjaxHandlerInspectable::$lastResponse = null;
+
+    AjaxHandlerInspectable::handle();
+
+    $_REQUEST = $savedRequest;
+
+    $response = AjaxHandlerInspectable::$lastResponse;
+    $this->assertIsArray($response, 'handle() with no args should populate $lastResponse from $_REQUEST');
+    $this->assertSame('from_request', $response['action']);
+    $this->assertSame(['action' => 'from_request', 'key' => 'val'], $response['params']);
+  }
+
+  public function test_handle_post_delegates_post_superglobal_to_handle()
+  {
+    $savedPost = $_POST;
+    $_POST     = ['action' => 'post_action', 'data' => 'posted'];
+    AjaxHandlerInspectable::$lastResponse = null;
+
+    AjaxHandlerInspectable::handle_post();
+
+    $_POST = $savedPost;
+
+    $response = AjaxHandlerInspectable::$lastResponse;
+    $this->assertIsArray($response);
+    $this->assertSame('posted', $response['params']['data']);
+  }
+
+  public function test_handle_get_delegates_get_superglobal_to_handle()
+  {
+    $savedGet = $_GET;
+    $_GET     = ['action' => 'get_action', 'q' => 'search_term'];
+    AjaxHandlerInspectable::$lastResponse = null;
+
+    AjaxHandlerInspectable::handle_get();
+
+    $_GET = $savedGet;
+
+    $response = AjaxHandlerInspectable::$lastResponse;
+    $this->assertIsArray($response);
+    $this->assertSame('search_term', $response['params']['q']);
+  }
+
+  // ---------------------------------------------------------------------------
+  // dispatch_action() failure modes
+  // ---------------------------------------------------------------------------
+
+  public function test_dispatch_action_throws_logic_exception_when_action_has_no_mapped_method()
+  {
+    $this->expectException(\LogicException::class);
+
+    $handler = new AjaxHandlerInspectable(['action' => 'unmapped_action']);
+    $handler->exposeDispatch();
+  }
+
+  public function test_dispatch_action_throws_bad_method_call_when_mapped_method_does_not_exist()
+  {
+    $this->expectException(\BadMethodCallException::class);
+
+    $handler = new AjaxHandlerInspectable(['action' => 'my_action']);
+    $handler->exposeMap('my_action', 'this_method_does_not_exist');
+    $handler->exposeDispatch();
+  }
+
+  public function test_dispatch_action_throws_bad_method_call_when_mapped_method_is_static()
+  {
+    // dispatch_action explicitly forbids static methods as handlers
+    $this->expectException(\BadMethodCallException::class);
+
+    $handler = new AjaxHandlerInspectable(['action' => 'my_action']);
+    $handler->exposeMap('my_action', 'aStaticMethod');
+    $handler->exposeDispatch();
+  }
+
+  // ---------------------------------------------------------------------------
+  // dispatch_action() + map_action() success path
+  // ---------------------------------------------------------------------------
+
+  public function test_dispatch_action_calls_mapped_instance_method_and_returns_its_result()
+  {
+    $handler = new AjaxHandlerInspectable(['action' => 'my_action']);
+    $handler->exposeMap('my_action', 'anInstanceMethod');
+
+    $result = $handler->exposeDispatch();
+
+    $this->assertSame(['dispatched_by' => 'anInstanceMethod'], $result);
+  }
+
+  public function test_map_action_returns_handler_instance_for_fluent_chaining()
+  {
+    $handler  = new AjaxHandlerInspectable(['action' => 'my_action']);
+    $returned = $handler->exposeMap('my_action', 'anInstanceMethod');
+
+    $this->assertSame($handler, $returned, 'map_action() should return $this for chaining');
+  }
+}
+
+/**
+ * Concrete test double for AbstractBase.
+ *
+ * – Overrides send_json_response() so tests do not depend on wp_send_json.
+ * – Exposes protected dispatch_action() and map_action() via public proxies.
+ * – Provides one valid instance method and one static method to exercise
+ *   dispatch_action failure/success paths.
+ */
+class AjaxHandlerInspectable extends AbstractBase
+{
+  /** Stores the last response captured by send_json_response(). */
+  public static ?array $lastResponse = null;
+
+  protected function execute(): array
+  {
+    return [
+      'action' => $this->action,
+      'params' => $this->request,
+      'cookies' => $this->cookie,
+    ];
+  }
+
+  /**
+   * Overridden to capture the response in a static property instead of
+   * calling wp_send_json, keeping handle/handle_post/handle_get tests
+   * free of wp_send_json WP_Mock expectations.
+   */
+  protected function send_json_response(array $response)
+  {
+    self::$lastResponse = $response;
+  }
+
+  public function exposeDispatch(): array
+  {
+    return $this->dispatch_action();
+  }
+
+  public function exposeMap(string $action, string $method): static
+  {
+    // map_action() returns $this; we explicitly re-return $this to let static
+    // analysis resolve the return type without traversing the parent's declaration.
+    $this->map_action($action, $method);
+    return $this;
+  }
+
+  /** Used to verify the success-path of dispatch_action(). */
+  protected function anInstanceMethod(): array
+  {
+    return ['dispatched_by' => 'anInstanceMethod'];
+  }
+
+  /** Used to verify that dispatch_action() rejects static methods. */
+  protected static function aStaticMethod(): array
+  {
+    return ['dispatched_by' => 'aStaticMethod'];
+  }
 }

--- a/test/unit/Form/FormTest.php
+++ b/test/unit/Form/FormTest.php
@@ -485,4 +485,131 @@ class FormTest extends Base
       ],
     ];
   }
+
+  // ---------------------------------------------------------------------------
+  // create_from_submission()
+  // ---------------------------------------------------------------------------
+
+  public function test_create_from_submission_returns_hydrated_instance_of_calling_class()
+  {
+    $form = FormSubmissionDouble::create_from_submission([
+      'first_name' => 'Ada',
+      'last_name'  => 'Lovelace',
+    ]);
+
+    $this->assertInstanceOf(FormSubmissionDouble::class, $form);
+    $this->assertSame('Ada', $form->get('first_name'));
+    $this->assertSame('Lovelace', $form->get('last_name'));
+  }
+
+  public function test_create_from_submission_ignores_fields_not_declared_on_form()
+  {
+    // Fields not in $this->fields should not be hydrated (whitelist behaviour)
+    $form = FormSubmissionDouble::create_from_submission([
+      'first_name'     => 'Grace',
+      'undeclared_key' => 'should be ignored',
+    ]);
+
+    $this->assertNull($form->get('undeclared_key'));
+  }
+
+  public function test_create_from_submission_throws_when_first_arg_is_not_an_array()
+  {
+    $this->expectException(\InvalidArgumentException::class);
+
+    FormSubmissionDouble::create_from_submission('not-an-array');
+  }
+
+  // ---------------------------------------------------------------------------
+  // has_errors()
+  // ---------------------------------------------------------------------------
+
+  public function test_has_errors_returns_false_when_no_errors_have_been_added()
+  {
+    $this->assertFalse($this->form->has_errors());
+  }
+
+  public function test_has_errors_returns_true_after_an_error_is_added()
+  {
+    $this->form->add_error('email', 'Invalid email address');
+
+    $this->assertTrue($this->form->has_errors());
+  }
+
+  // ---------------------------------------------------------------------------
+  // has_errors_for()
+  // ---------------------------------------------------------------------------
+
+  public function test_has_errors_for_returns_false_for_field_with_no_errors()
+  {
+    $this->form->add_error('email', 'Invalid');
+
+    $this->assertFalse($this->form->has_errors_for('username'));
+  }
+
+  public function test_has_errors_for_returns_true_for_field_that_has_errors()
+  {
+    $this->form->add_error('email', 'Invalid email address');
+
+    $this->assertTrue($this->form->has_errors_for('email'));
+  }
+
+  // ---------------------------------------------------------------------------
+  // succeeded()
+  // ---------------------------------------------------------------------------
+
+  public function test_succeeded_returns_false_by_default()
+  {
+    $this->assertFalse($this->form->succeeded());
+  }
+
+  public function test_succeeded_returns_true_when_internal_success_flag_is_set()
+  {
+    $this->setProtectedProperty($this->form, 'success', true);
+
+    $this->assertTrue($this->form->succeeded());
+  }
+
+  // ---------------------------------------------------------------------------
+  // get_unique_error_messages()
+  // ---------------------------------------------------------------------------
+
+  public function test_get_unique_error_messages_returns_empty_array_when_no_errors()
+  {
+    $this->assertSame([], $this->form->get_unique_error_messages());
+  }
+
+  public function test_get_unique_error_messages_deduplicates_identical_messages_across_fields()
+  {
+    // "Required" appears twice (for two different fields) but must only appear once in the output
+    $this->form->add_error('first_name', 'Required');
+    $this->form->add_error('last_name',  'Required');
+    $this->form->add_error('email',      'Must be a valid email address');
+
+    $unique = array_values($this->form->get_unique_error_messages());
+
+    $this->assertEquals(['Required', 'Must be a valid email address'], $unique);
+  }
+}
+
+/**
+ * Minimal concrete subclass of AbstractBase used to test create_from_submission()
+ * and other methods that depend on a concrete class being instantiated.
+ */
+class FormSubmissionDouble extends AbstractBase
+{
+  public function __construct()
+  {
+    parent::__construct();
+
+    $this->fields = [
+      'first_name' => [],
+      'last_name'  => [],
+    ];
+  }
+
+  public function process(array $request): void
+  {
+    // test double — no-op implementation of required abstract method
+  }
 }

--- a/test/unit/SiteTest.php
+++ b/test/unit/SiteTest.php
@@ -78,7 +78,6 @@ class SiteTest extends Base
     ]);
     WP_Mock::userFunction('get_stylesheet_directory', [
       'return' => self::THEME_DIRECTORY,
-      'times' => 4,
     ]);
 
     WP_Mock::userFunction('get_locale', [
@@ -143,13 +142,15 @@ class SiteTest extends Base
   public function test_get_assets_version()
   {
 
-    $site = new Site();
-
-    // We will set the stylesheet directory to our virtual file system directory
-    WP_Mock::userFunction('get_stylesheet_directory', [
-      'return' => vfsStream::url('root/theme-dir'),
-      'times' => 2,
-    ]);
+    $path = vfsStream::url('root/theme-dir/assets.version');
+    $site = $this->getMockBuilder(Site::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['get_theme_file'])
+      ->getMock();
+    $site->expects($this->exactly(2))
+      ->method('get_theme_file')
+      ->with('assets.version')
+      ->willReturn($path);
 
     // read the file value from our file in the virtual file system directory
     $this->assertEquals(
@@ -161,13 +162,15 @@ class SiteTest extends Base
   public function test_get_assets_version_with_arg()
   {
 
-    $site = new Site();
-
-    // We will set the stylesheet directory to our virtual file system directory
-    WP_Mock::userFunction('get_stylesheet_directory', [
-      'return' => vfsStream::url('root/theme-dir'),
-      'times' => 2,
-    ]);
+    $path = vfsStream::url('root/theme-dir/custom-assets.version');
+    $site = $this->getMockBuilder(Site::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['get_theme_file'])
+      ->getMock();
+    $site->expects($this->exactly(2))
+      ->method('get_theme_file')
+      ->with('custom-assets.version')
+      ->willReturn($path);
 
     // read the file value from our file in the virtual file system directory
     $this->assertEquals(
@@ -179,13 +182,19 @@ class SiteTest extends Base
   public function test_subsequent_get_assets_version_with()
   {
 
-    $site = new Site();
-
-    // We will set the stylesheet directory to our virtual file system directory
-    WP_Mock::userFunction('get_stylesheet_directory', [
-      'return' => vfsStream::url('root/theme-dir'),
-      'times' => 4,
-    ]);
+    $paths = [
+      'custom-assets.version' => vfsStream::url('root/theme-dir/custom-assets.version'),
+      'assets.version' => vfsStream::url('root/theme-dir/assets.version'),
+    ];
+    $site = $this->getMockBuilder(Site::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['get_theme_file'])
+      ->getMock();
+    $site->expects($this->exactly(4))
+      ->method('get_theme_file')
+      ->willReturnCallback(function (string $file) use ($paths) {
+        return $paths[$file];
+      });
 
     // read the file value from our file in the virtual file system directory
     $this->assertEquals(
@@ -201,17 +210,19 @@ class SiteTest extends Base
   public function test_get_assets_version_with_no_file()
   {
 
-    $site = new Site();
+    $site = $this->getMockBuilder(Site::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['get_theme_file'])
+      ->getMock();
 
     $this->file_system = vfsStream::setup('root', null, [
       'theme-dir' => [],
     ]);
 
-    // We will set the stylesheet directory to our virtual file system directory
-    WP_Mock::userFunction('get_stylesheet_directory', [
-      'return' => vfsStream::url('root/theme-dir'),
-      'times' => 1,
-    ]);
+    $site->expects($this->once())
+      ->method('get_theme_file')
+      ->with('assets.version')
+      ->willReturn(vfsStream::url('root/theme-dir/assets.version'));
 
     // read the file value from our file in the virtual file system directory
     $this->assertEquals('', $site->get_assets_version());
@@ -283,5 +294,411 @@ class SiteTest extends Base
       $twig,
       $site->get_twig_with_helper($twig, $helper)
     );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Return a Site partial mock with the constructor disabled.
+   * Only the listed methods are stubbed; all other methods call the real
+   * implementation, which is required so the hook-registration logic executes.
+   *
+   * @param string[] $methodsToStub Method names to stub on the mock.
+   */
+  private function makeSiteMock(array $methodsToStub = []): Site
+  {
+    return $this->getMockBuilder(Site::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods($methodsToStub)
+      ->getMock();
+  }
+
+  // ---------------------------------------------------------------------------
+  // configure()
+  // ---------------------------------------------------------------------------
+
+  public function test_configure_calls_defaults_invokes_user_callback_and_returns_self()
+  {
+    $site = $this->getMockBuilder(Site::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['configure_defaults'])
+      ->getMock();
+
+    // configure_defaults must be called exactly once when the flag is true (default)
+    $site->expects($this->once())->method('configure_defaults');
+
+    $callbackInvoked = false;
+    $capturedSelf    = null;
+
+    $result = $site->configure(function () use (&$callbackInvoked, &$capturedSelf) {
+      $callbackInvoked = true;
+      // The callback is bound via Closure::call($this), so $this is the Site instance
+      $capturedSelf = $this;
+    });
+
+    $this->assertTrue($callbackInvoked, 'User-defined callback was not invoked');
+    $this->assertSame($site, $capturedSelf, 'Callback $this should be bound to the Site instance');
+    $this->assertSame($site, $result, 'configure() must return $this for fluent chaining');
+  }
+
+  public function test_configure_skips_defaults_when_flag_is_false()
+  {
+    $site = $this->getMockBuilder(Site::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['configure_defaults'])
+      ->getMock();
+
+    $site->expects($this->never())->method('configure_defaults');
+
+    $result = $site->configure(null, false);
+
+    $this->assertSame($site, $result, 'configure() must return $this even when skipping defaults');
+  }
+
+  public function test_configure_with_null_callback_still_calls_defaults()
+  {
+    $site = $this->getMockBuilder(Site::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['configure_defaults'])
+      ->getMock();
+
+    $site->expects($this->once())->method('configure_defaults');
+
+    $result = $site->configure(null);
+
+    $this->assertSame($site, $result);
+  }
+
+  // ---------------------------------------------------------------------------
+  // configure_default_classmaps()
+  // ---------------------------------------------------------------------------
+
+  public function test_configure_default_classmaps_registers_timber_classmap_filter()
+  {
+    $site = $this->makeSiteMock();
+
+    WP_Mock::expectFilterAdded('timber/post/classmap', WP_Mock\Functions::type('callable'));
+
+    $this->assertNull($site->configure_default_classmaps());
+  }
+
+  // ---------------------------------------------------------------------------
+  // register_script()
+  // ---------------------------------------------------------------------------
+
+  public function test_register_script_resolves_version_from_custom_file_key()
+  {
+    // When $version is ['file' => '...'], the named file's contents are used as the version
+    $site = $this->getMockBuilder(Site::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['get_assets_version', 'get_script_uri'])
+      ->getMock();
+
+    $site->expects($this->once())
+      ->method('get_assets_version')
+      ->with('my.version')
+      ->willReturn('v1.2');
+    $site->method('get_script_uri')
+      ->with('main.js')
+      ->willReturn('https://cdn.example.com/main.js');
+
+    WP_Mock::userFunction('wp_register_script', [
+      'times' => 1,
+      'args'  => ['my-script', 'https://cdn.example.com/main.js', [], 'v1.2', true],
+    ]);
+
+    $site->register_script('my-script', 'main.js', [], ['file' => 'my.version']);
+  }
+
+  public function test_register_script_auto_resolves_version_when_true()
+  {
+    // When $version === true, get_assets_version() is called with the default file arg
+    $site = $this->getMockBuilder(Site::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['get_assets_version', 'get_script_uri'])
+      ->getMock();
+
+    $site->expects($this->once())
+      ->method('get_assets_version')
+      ->willReturn('auto-ver');
+    $site->method('get_script_uri')->willReturn('https://cdn.example.com/auto.js');
+
+    WP_Mock::userFunction('wp_register_script', [
+      'times' => 1,
+      'args'  => ['auto-script', 'https://cdn.example.com/auto.js', [], 'auto-ver', true],
+    ]);
+
+    $site->register_script('auto-script', 'auto.js', [], true);
+  }
+
+  public function test_register_script_passes_explicit_version_string_without_resolution()
+  {
+    // An explicit string version bypasses the assets-version file lookup entirely
+    $site = $this->getMockBuilder(Site::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['get_assets_version', 'get_script_uri'])
+      ->getMock();
+
+    $site->expects($this->never())->method('get_assets_version');
+    $site->method('get_script_uri')->willReturn('https://cdn.example.com/pinned.js');
+
+    WP_Mock::userFunction('wp_register_script', [
+      'times' => 1,
+      'args'  => ['pinned-script', 'https://cdn.example.com/pinned.js', [], '3.0.0', false],
+    ]);
+
+    $site->register_script('pinned-script', 'pinned.js', [], '3.0.0', false);
+  }
+
+  // ---------------------------------------------------------------------------
+  // enqueue_script()
+  // ---------------------------------------------------------------------------
+
+  public function test_enqueue_script_resolves_version_from_custom_file_key()
+  {
+    $site = $this->getMockBuilder(Site::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['get_assets_version', 'get_script_uri'])
+      ->getMock();
+
+    $site->expects($this->once())
+      ->method('get_assets_version')
+      ->with('app.version')
+      ->willReturn('enq-v1');
+    $site->method('get_script_uri')->willReturn('https://cdn.example.com/enq.js');
+
+    WP_Mock::userFunction('wp_enqueue_script', [
+      'times' => 1,
+      'args'  => ['enq-script', 'https://cdn.example.com/enq.js', ['dep'], 'enq-v1', true],
+    ]);
+
+    $site->enqueue_script('enq-script', 'enq.js', ['dep'], ['file' => 'app.version']);
+  }
+
+  public function test_enqueue_script_passes_explicit_version_string_without_resolution()
+  {
+    $site = $this->getMockBuilder(Site::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['get_assets_version', 'get_script_uri'])
+      ->getMock();
+
+    $site->expects($this->never())->method('get_assets_version');
+    $site->method('get_script_uri')->willReturn('https://cdn.example.com/pinned.js');
+
+    WP_Mock::userFunction('wp_enqueue_script', [
+      'times' => 1,
+      'args'  => ['pinned-enq', 'https://cdn.example.com/pinned.js', [], '2.0', false],
+    ]);
+
+    $site->enqueue_script('pinned-enq', 'pinned.js', [], '2.0', false);
+  }
+
+  // ---------------------------------------------------------------------------
+  // register_style()
+  // ---------------------------------------------------------------------------
+
+  public function test_register_style_resolves_version_from_custom_file_key()
+  {
+    $site = $this->getMockBuilder(Site::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['get_assets_version', 'get_stylesheet_uri'])
+      ->getMock();
+
+    $site->expects($this->once())
+      ->method('get_assets_version')
+      ->with('css.version')
+      ->willReturn('css-v2');
+    $site->method('get_stylesheet_uri')->willReturn('https://cdn.example.com/style.css');
+
+    WP_Mock::userFunction('wp_register_style', [
+      'times' => 1,
+      'args'  => ['theme-style', 'https://cdn.example.com/style.css', [], 'css-v2', 'all'],
+    ]);
+
+    $site->register_style('theme-style', 'style.css', [], ['file' => 'css.version']);
+  }
+
+  public function test_register_style_passes_explicit_version_string_without_resolution()
+  {
+    $site = $this->getMockBuilder(Site::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['get_assets_version', 'get_stylesheet_uri'])
+      ->getMock();
+
+    $site->expects($this->never())->method('get_assets_version');
+    $site->method('get_stylesheet_uri')->willReturn('https://cdn.example.com/pinned.css');
+
+    WP_Mock::userFunction('wp_register_style', [
+      'times' => 1,
+      'args'  => ['pinned-style', 'https://cdn.example.com/pinned.css', [], '1.5', 'screen'],
+    ]);
+
+    $site->register_style('pinned-style', 'pinned.css', [], '1.5', 'screen');
+  }
+
+  // ---------------------------------------------------------------------------
+  // enqueue_style()
+  // ---------------------------------------------------------------------------
+
+  public function test_enqueue_style_auto_resolves_version_when_true()
+  {
+    $site = $this->getMockBuilder(Site::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['get_assets_version', 'get_stylesheet_uri'])
+      ->getMock();
+
+    $site->expects($this->once())
+      ->method('get_assets_version')
+      ->willReturn('auto-css');
+    $site->method('get_stylesheet_uri')->willReturn('https://cdn.example.com/auto.css');
+
+    WP_Mock::userFunction('wp_enqueue_style', [
+      'times' => 1,
+      'args'  => ['auto-style', 'https://cdn.example.com/auto.css', [], 'auto-css', 'all'],
+    ]);
+
+    $site->enqueue_style('auto-style', 'auto.css', [], true);
+  }
+
+  public function test_enqueue_style_passes_explicit_version_string_without_resolution()
+  {
+    $site = $this->getMockBuilder(Site::class)
+      ->disableOriginalConstructor()
+      ->onlyMethods(['get_assets_version', 'get_stylesheet_uri'])
+      ->getMock();
+
+    $site->expects($this->never())->method('get_assets_version');
+    $site->method('get_stylesheet_uri')->willReturn('https://cdn.example.com/pinned-e.css');
+
+    WP_Mock::userFunction('wp_enqueue_style', [
+      'times' => 1,
+      'args'  => ['pinned-enq-style', 'https://cdn.example.com/pinned-e.css', [], '4.0', 'print'],
+    ]);
+
+    $site->enqueue_style('pinned-enq-style', 'pinned.css', [], '4.0', 'print');
+  }
+
+  // ---------------------------------------------------------------------------
+  // add_to_context()
+  // ---------------------------------------------------------------------------
+
+  public function test_add_to_context_populates_all_required_context_keys()
+  {
+    $site = $this->makeSiteMock();
+
+    $mockMenu = new \stdClass();
+
+    // Timber::get_menu is a static call; intercept it via a Mockery alias mock
+    $timber = \Mockery::mock('alias:Timber\\Timber');
+    $timber->shouldReceive('get_menu')
+      ->once()
+      ->with('primary')
+      ->andReturn($mockMenu);
+
+    WP_Mock::userFunction('get_body_class', [
+      'times'  => 1,
+      'return' => ['page-template-default', 'logged-in'],
+    ]);
+    WP_Mock::userFunction('get_search_query', [
+      'times'  => 1,
+      'return' => 'conifer test',
+    ]);
+
+    $result = $site->add_to_context([]);
+
+    $this->assertSame($site, $result['site'], '"site" key should be the Site instance');
+    $this->assertSame($mockMenu, $result['primary_menu']);
+    $this->assertSame(['page-template-default', 'logged-in'], $result['body_classes']);
+    $this->assertSame('conifer test', $result['search_query']);
+  }
+
+  public function test_add_to_context_merges_caller_data_with_defaults()
+  {
+    $site = $this->makeSiteMock();
+
+    $timber = \Mockery::mock('alias:Timber\\Timber');
+    $timber->shouldReceive('get_menu')->andReturn(null);
+
+    WP_Mock::userFunction('get_body_class', ['return' => []]);
+    WP_Mock::userFunction('get_search_query', ['return' => '']);
+
+    $result = $site->add_to_context(['extra_key' => 'extra_value']);
+
+    $this->assertSame('extra_value', $result['extra_key'], 'Caller-provided data should be present in result');
+    // All default keys must still be populated
+    $this->assertArrayHasKey('site', $result);
+    $this->assertArrayHasKey('primary_menu', $result);
+    $this->assertArrayHasKey('body_classes', $result);
+    $this->assertArrayHasKey('search_query', $result);
+  }
+
+  // ---------------------------------------------------------------------------
+  // configure_default_admin_dashboard_widgets() / remove_conifer_widget()
+  // ---------------------------------------------------------------------------
+
+  public function test_configure_default_admin_dashboard_widgets_registers_setup_action()
+  {
+    $site = $this->makeSiteMock();
+
+    WP_Mock::expectActionAdded('wp_dashboard_setup', WP_Mock\Functions::type('callable'));
+
+    $this->assertNull($site->configure_default_admin_dashboard_widgets());
+  }
+
+  public function test_remove_conifer_widget_registers_setup_action()
+  {
+    $site = $this->makeSiteMock();
+
+    WP_Mock::expectActionAdded('wp_dashboard_setup', WP_Mock\Functions::type('callable'));
+
+    $this->assertNull($site->remove_conifer_widget());
+  }
+
+  // ---------------------------------------------------------------------------
+  // enable_admin_hotkeys() / disable_admin_hotkeys()
+  // ---------------------------------------------------------------------------
+
+  public function test_enable_admin_hotkeys_registers_enqueue_scripts_action()
+  {
+    $site = $this->makeSiteMock();
+
+    WP_Mock::expectActionAdded('admin_enqueue_scripts', WP_Mock\Functions::type('callable'));
+
+    $this->assertNull($site->enable_admin_hotkeys());
+  }
+
+  public function test_disable_admin_hotkeys_registers_enqueue_scripts_action()
+  {
+    $site = $this->makeSiteMock();
+
+    WP_Mock::expectActionAdded('admin_enqueue_scripts', WP_Mock\Functions::type('callable'));
+
+    $this->assertNull($site->disable_admin_hotkeys());
+  }
+
+  // ---------------------------------------------------------------------------
+  // disable_comments()
+  // ---------------------------------------------------------------------------
+
+  public function test_disable_comments_registers_all_required_actions_and_filters()
+  {
+    $site = $this->makeSiteMock();
+
+    // Actions
+    WP_Mock::expectActionAdded('admin_init', WP_Mock\Functions::type('callable'));
+    WP_Mock::expectActionAdded('admin_menu', WP_Mock\Functions::type('callable'));
+    WP_Mock::expectActionAdded('wp_before_admin_bar_render', WP_Mock\Functions::type('callable'));
+
+    // Closure-based filter
+    WP_Mock::expectFilterAdded('manage_page_columns', WP_Mock\Functions::type('callable'));
+
+    // String-callback filters with non-default priorities
+    WP_Mock::expectFilterAdded('comments_array', '__return_empty_array');
+    WP_Mock::expectFilterAdded('comments_open', '__return_false', 20);
+    WP_Mock::expectFilterAdded('pings_open', '__return_false', 20);
+
+    $this->assertNull($site->disable_comments());
   }
 }


### PR DESCRIPTION
**Ticket**: # [GRT-240](https://sitecrafting.atlassian.net/browse/GRT-240)

#### Issue

The first round of test suite upgrades did not cover all of the functionality in Conifer. This PR fixes this.

#### Solution

This PR expands the scope of testing for SiteTest, FormTest, AjaxHandlerTest, and AdminNoticeTest.


[GRT-240]: https://sitecrafting.atlassian.net/browse/GRT-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ