### PR TITLE
Update/further test updates

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -58,5 +58,11 @@ jobs:
             - name: Run integration tests
               run: ./vendor/bin/phpunit --configuration phpunit-integration.xml.dist
 
+            - name: Run unit tests in multisite mode
+              run: ./vendor/bin/phpunit --configuration phpunit-multisite.xml.dist
+
+            - name: Run integration tests in multisite mode
+              run: ./vendor/bin/phpunit --configuration phpunit-integration-multisite.xml.dist
+
             # - name: Run code sniffing
             #   run: composer sniff

--- a/.lando.yml
+++ b/.lando.yml
@@ -65,6 +65,16 @@ tooling:
         cmd: './vendor/bin/phpunit --config phpunit-integration.xml.dist'
         description: 'Run integration tests'
 
+    unit-multisite:
+        service: appserver
+        cmd: './vendor/bin/phpunit --config phpunit-multisite.xml.dist'
+        description: 'Run unit tests for multisite'
+
+    integration-multisite:
+        service: appserver
+        cmd: './vendor/bin/phpunit --config phpunit-integration-multisite.xml.dist'
+        description: 'Run integration tests for multisite'
+
     test:
         service: appserver
         cmd:

--- a/.lando.yml
+++ b/.lando.yml
@@ -82,6 +82,13 @@ tooling:
             - vendor/bin/phpunit --config phpunit-integration.xml.dist
         description: 'Run all unit and integration tests'
 
+    test-multisite:
+        service: appserver
+        cmd:
+            - vendor/bin/phpunit --config phpunit-multisite.xml.dist
+            - vendor/bin/phpunit --config phpunit-integration-multisite.xml.dist
+        description: 'Run all unit and integration tests in multisite mode'
+
     install-tests:
         service: appserver
         cmd: './scripts/install-wp-tests.sh'

--- a/phpunit-integration-multisite.xml.dist
+++ b/phpunit-integration-multisite.xml.dist
@@ -1,0 +1,18 @@
+<phpunit
+    bootstrap="./test/bootstrap-integration.php"
+    backupGlobals="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+>
+    <php>
+		<env name="WP_MULTISITE" value="1"/>
+	</php>
+    <testsuites>
+        <testsuite name="integration (multisite)">
+            <directory suffix=".php">./test/integration</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/phpunit-multisite.xml.dist
+++ b/phpunit-multisite.xml.dist
@@ -1,0 +1,18 @@
+<phpunit
+    bootstrap="./test/bootstrap.php"
+    backupGlobals="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+>
+    <php>
+		<env name="WP_MULTISITE" value="1"/>
+	</php>
+    <testsuites>
+        <testsuite name="unit (multisite)">
+            <directory suffix=".php">./test/unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/test/bootstrap-integration.php
+++ b/test/bootstrap-integration.php
@@ -8,6 +8,12 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+// Check for multisite mode
+if (getenv('WP_MULTISITE')) {
+  define('MULTISITE', true);
+  define('SUBDOMAIN_INSTALL', false);
+}
+
 if (is_dir(__DIR__ . '/wp-tests-lib')) {
   require_once __DIR__ . '/wp-tests-lib/includes/functions.php';
   require_once __DIR__ . '/wp-tests-lib/includes/bootstrap.php';

--- a/test/bootstrap-integration.php
+++ b/test/bootstrap-integration.php
@@ -12,3 +12,5 @@ if (is_dir(__DIR__ . '/wp-tests-lib')) {
   require_once __DIR__ . '/wp-tests-lib/includes/functions.php';
   require_once __DIR__ . '/wp-tests-lib/includes/bootstrap.php';
 }
+
+require_once __DIR__ . '/integration/Base.php';

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -3,13 +3,11 @@
 /**
  * Conifer test suite bootstrap file; included before every unit test run
  *
- * @todo remove dependency on WP_Mock
  * @copyright 2020 SiteCrafting, Inc.
  * @author    Coby Tamayo <ctamayo@sitecrafting.com>
  */
 
 require_once __DIR__ . '/../vendor/autoload.php';
-
 
 /*
  * Define some WP constants that are referenced directly in Conifer
@@ -18,6 +16,12 @@ define('ABSPATH', realpath(__DIR__ . '/../'));
 define('WP_PLUGIN_DIR', ABSPATH . '/wp-content/plugins');
 define('WP_CONTENT_URL', 'http://appserver/wp-content');
 define('WPMU_PLUGIN_DIR', ABSPATH . '/wp-content/plugins');
+
+// Check for multisite mode
+if (getenv('WP_MULTISITE')) {
+  define('MULTISITE', true);
+  define('SUBDOMAIN_INSTALL', false);
+}
 
 /**
  * Define our own version of apply_filters_deprecated, rather than mocking,

--- a/test/integration/AdminPageTest.php
+++ b/test/integration/AdminPageTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Conifer\Integration;
+
+use Timber\Timber;
+
+class SimpleAdminPage extends \Conifer\Admin\Page
+{
+    public function render(array $data = []): string
+    {
+        $title = $data['title'] ?? 'Simple Admin Page';
+
+        return "<h1>{$title}</h1>";
+    }
+}
+
+class SimpleSubPage extends \Conifer\Admin\SubPage
+{
+    public function render(array $data = []): string
+    {
+        $title = $data['title'] ?? 'Simple Sub Page';
+
+        return "<h1>{$title}</h1>";
+    }
+}
+
+class AdminPageTest extends Base
+{
+    public function test_admin_page_render_without_data_argument()
+    {
+        $page = new SimpleAdminPage('Simple Admin');
+
+        $this->assertSame('<h1>Simple Admin Page</h1>', $page->render());
+    }
+
+    public function test_admin_page_render_with_data_argument()
+    {
+        $page = new SimpleAdminPage('Simple Admin');
+
+        $this->assertSame(
+            '<h1>Custom Admin Title</h1>',
+            $page->render(['title' => 'Custom Admin Title'])
+        );
+    }
+
+    public function test_sub_page_render_without_data_argument()
+    {
+        $parent = new SimpleAdminPage('Parent Admin');
+        $subPage = new SimpleSubPage($parent, 'Simple Sub');
+
+        $this->assertSame('<h1>Simple Sub Page</h1>', $subPage->render());
+    }
+
+    public function test_sub_page_render_with_data_argument()
+    {
+        $parent = new SimpleAdminPage('Parent Admin');
+        $subPage = new SimpleSubPage($parent, 'Simple Sub');
+
+        $this->assertSame(
+            '<h1>Custom Sub Title</h1>',
+            $subPage->render(['title' => 'Custom Sub Title'])
+        );
+    }
+}

--- a/test/integration/Base.php
+++ b/test/integration/Base.php
@@ -31,4 +31,10 @@ abstract class Base extends WP_UnitTestCase
     $this->site = new Site();
     $this->site->configure_defaults();
   }
+
+  public function test_is_multisite()
+  {
+    $isMultisite = defined('MULTISITE') && MULTISITE;
+    $this->assertEquals(getenv('WP_MULTISITE') ? true : false, $isMultisite);
+  }
 }

--- a/test/unit/Base.php
+++ b/test/unit/Base.php
@@ -181,4 +181,10 @@ abstract class Base extends TestCase
       'return' => $data,
     ]);
   }
+
+  public function test_multisite_mode()
+  {
+    $isMultisite = defined('MULTISITE') && MULTISITE;
+    $this->assertEquals(getenv('WP_MULTISITE') ? true : false, $isMultisite);
+  }
 }


### PR DESCRIPTION
**Ticket**: # <!-- ignore this if you're not addressing [specific issue](https://github.com/sitecrafting/conifer/issues) -->

#### Issue

- [Conifer lacks integration tests for the ::render() function](https://sitecrafting.atlassian.net/browse/GRT-263)
- [Unit and integration tests to not currently support multisite mode](https://sitecrafting.atlassian.net/browse/GRT-254)

#### Solution

Adds support for testing the ::render() method, and adds multisite support

#### Impact

None

#### Usage Changes

Introduces two new Lando commands: `lando unit-multisite` and `lando integration-multisite`
