### PR TITLE
Update/ajax logging

### DIFF
--- a/docs/ajax-handlers.md
+++ b/docs/ajax-handlers.md
@@ -7,8 +7,8 @@ Conifer provides an elegant and flexible abstraction of the standard [WordPress 
 use Conifer\AjaxHandler\AbstractBase;
 
 class MyAjaxHandler extends AbstractBase {
-  protected function execute() : array {
-    /* 
+  protected function execute(): array {
+    /*
     * Your custom logic goes here
     * Request data is accessible via $this->request
     * Return an array with the appropriate response data
@@ -45,7 +45,7 @@ use Conifer\AjaxHandler\AbstractBase;
   
 class RobotAjaxHandler extends AbstractBase {
   // Implement the abstract execute method
-  protected function execute() {
+  protected function execute(): array {
     // Map actions to instance methods dynamically
     $this->map_action('talk_to_robot', 'talk_to_robot');
     $this->map_action('ask_robot_to_dance', 'robot_dance');
@@ -87,23 +87,60 @@ add_action('wp_ajax_ask_robot_to_dance', [RobotAjaxHandler::class, 'handle']);
 add_action('wp_ajax_buy_robot_insurance', [RobotAjaxHandler::class, 'handle']);
 ```
 
+## Logging
+
+`AbstractBase` accepts an optional [PSR-3](https://www.php-fig.org/psr/psr-3/) `LoggerInterface` when it is constructed. Once configured, call `log()` from your handler to write messages at any supported PSR-3 log level.
+
+Pass the logger as the second argument when constructing a handler directly. The static `handle()` method creates the handler with only the request data, so subclasses that use it must obtain their logger before calling the parent constructor.
+
+```PHP
+declare(strict_types=1)
+
+use Conifer\AjaxHandler\AbstractBase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+class RobotAjaxHandler extends AbstractBase {
+
+  public function __construct(array $request, ?LoggerInterface $logger = null) {
+    parent::__construct($request, $logger);
+  }
+
+  protected function execute(): array {
+    try {
+      $this->doNotDoTheThing();
+    } catch (\Exception $e) {
+      // log() defaults to the debug log level.
+      self::log($e->getMessage());
+
+      // Pass a log level as the second argument when needed.
+      self::log($e->getMessage(), LogLevel::CRITICAL);
+    }
+
+    return [];
+  }
+}
+```
+
+Calling `log()` without a configured logger throws a `RuntimeException`. Passing a value other than a [PSR-3 log level](https://www.php-fig.org/psr/psr-3/#5-psrlogloglevel) throws an `InvalidArgumentException`.
+
 ## API
 The AjaxHandler class provides a relatively thin layer of abstraction, but there are a handful of available methods you should be aware of:
 
 
-### `handle(array $data)`
+### `handle(?array $requestData = null)`
 
-The method which is called when AJAX requests and received. Utilizes data from the [$_REQUEST](http://php.net/manual/en/reserved.variables.request.php) suberglobal, which will include data from both POST and GET requests.
+The method called when an AJAX request is received. When no request data is passed, it uses data from the [$_REQUEST](http://php.net/manual/en/reserved.variables.request.php) superglobal, which includes data from both POST and GET requests.
 
 
 ### `handle_post()`
 
-Can be used in place of the `handle` method when adding your AJAX action. Only utilizes data from the [$_POST](http://php.net/manual/en/reserved.variables.post.php) suberglobal, which limits your AJAX handler to only accepting POST requests.
+Can be used in place of the `handle` method when adding your AJAX action. Uses data only from the [$_POST](http://php.net/manual/en/reserved.variables.post.php) superglobal, which limits your AJAX handler to accepting only POST requests.
 
 
 ### `handle_get()`
 
-Can be used in place of the `handle` method when adding your AJAX action. Only utilizes data from the [$_GET](http://php.net/manual/en/reserved.variables.get.php) suberglobal, which limits your AJAX handler to only accepting GET requests.
+Can be used in place of the `handle` method when adding your AJAX action. Uses data only from the [$_GET](http://php.net/manual/en/reserved.variables.get.php) superglobal, which limits your AJAX handler to accepting only GET requests.
 
 
 ### `param(mixed $name)`

--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -3,3 +3,6 @@
 * Update multiple dependencies.
 * Remove dependencies that were no longer needed.
 * Migrate from [Gitbook](https://www.gitbook.com) to [VitePress](https://vitepress.dev).
+
+## v1.0.5
+* Updated AbstractBase with static logging.

--- a/lib/Conifer/AjaxHandler/AbstractBase.php
+++ b/lib/Conifer/AjaxHandler/AbstractBase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Class to encapsulate handling AJAX calls. Handling a WP AJAX action
  * requires only implementing a child class with an execute() method,
@@ -74,12 +75,17 @@
 namespace Conifer\AjaxHandler;
 
 use BadMethodCallException;
+use InvalidArgumentException;
 use LogicException;
 use ReflectionClass;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use RuntimeException;
+use Stringable;
 
-// TODO: Need to address logging for AJAX requests. Stripped logging out for now. See #25
 // TODO: Need to add nonce verification to this class and update any related documentation to reflect this requirement
-abstract class AbstractBase {
+abstract class AbstractBase
+{
   /**
    * The request array for this AJAX request (either POST or GET)
    *
@@ -106,12 +112,19 @@ abstract class AbstractBase {
   protected $action_methods;
 
   /**
+   * Logger for logging information about Ajax Requests
+   *
+   * @var LoggerInterface|null
+   */
+  protected static ?LoggerInterface $logger = null;
+
+  /**
    * Abstract method used to define the functionality when handling an AJAX request.
    * Should return an array to be encoded in the response.
    *
    * @return array The response after handling the request
    */
-  abstract protected function execute() : array;
+  abstract protected function execute(): array;
 
 
   /*
@@ -121,7 +134,8 @@ abstract class AbstractBase {
   /**
    * Handle an HTTP request.
    */
-  public static function handle(?array $requestData = null) {
+  public static function handle(?array $requestData = null)
+  {
     // phpcs:ignore WordPress.Security.NonceVerification.Recommended
     $handler = new static($requestData ?? $_REQUEST);
     $handler->set_cookie($_COOKIE);
@@ -131,30 +145,73 @@ abstract class AbstractBase {
   /**
    * Handle an HTTP POST request.
    */
-  public static function handle_post() {
+  public static function handle_post()
+  {
     static::handle($_POST); // phpcs:ignore WordPress.Security.NonceVerification.Missing
   }
 
   /**
    * Handle an HTTP GET request.
    */
-  public static function handle_get() {
+  public static function handle_get()
+  {
     static::handle($_GET); // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
   }
 
+  /**
+   * Log a provided string message to the configured log file.
+   *
+   * This is not a 100% accurate implementation of the LoggerInterface log() function, but it
+   * should be good enough to suit our needs
+   *
+   * @param string|Stringable $message The message to log
+   * @param string $level The log level to use. Defaults to LogLevel::DEBUG
+   * @return void
+   *
+   * @throws RuntimeException If the logger is not configured via __construct
+   * @throws InvalidArgumentException If the provided $level is not one of PSR-3's LogLevels
+   */
+  public static function log(string|Stringable $message, string $level = LogLevel::DEBUG): void
+  {
+    // If the logger is not set, we cannot log the message. We should throw a runtime exception.
+    if (static::$logger === null) {
+      throw new \RuntimeException('Logger is not set. Cannot log message.');
+    }
+
+    // If the message is a Stringable object, we need to convert it to a string.
+    if ($message instanceof Stringable) {
+      $message = (string) $message;
+    }
+
+    // Check to make sure the level is valid. If not, throw an InvalidArgumentException.
+    switch ($level) {
+      case LogLevel::EMERGENCY:
+      case LogLevel::ALERT:
+      case LogLevel::CRITICAL:
+      case LogLevel::ERROR:
+      case LogLevel::WARNING:
+      case LogLevel::NOTICE:
+      case LogLevel::INFO:
+      case LogLevel::DEBUG:
+        static::$logger->{$level}($message);
+        break;
+      default:
+        throw new \InvalidArgumentException("Invalid log level: {$level}");
+    }
+  }
 
   /*
    * Instance Methods
    */
 
   /**
-   * Constructor.
-   * TODO decide whether to require Monolog??
+   * Constructor
    *
    * @param array $request the raw request params, i.e. GET/POST
    * @throws LogicException If the request array doesn't contain an action
    */
-  public function __construct(array $request) {
+  public function __construct(array $request, ?LoggerInterface $logger = null)
+  {
     if (empty($request['action'])) {
       throw new LogicException(
         'Trying to handle an AJAX call without an action! The "action" request parameter is required.'
@@ -164,6 +221,7 @@ abstract class AbstractBase {
     $this->action         = $request['action'];
     $this->request        = $request;
     $this->action_methods = [];
+    static::$logger       = $logger;
   }
 
   /**
@@ -171,7 +229,8 @@ abstract class AbstractBase {
    *
    * @param array $response the response to be converted to JSON
    */
-  protected function send_json_response(array $response) {
+  protected function send_json_response(array $response)
+  {
     wp_send_json($response);
   }
 
@@ -181,7 +240,8 @@ abstract class AbstractBase {
    * @param mixed $name the key of the value to get from the request
    * @return mixed the value for the request param. Defaults to the empty string if not set.
    */
-  protected function param($name) {
+  protected function param($name)
+  {
     return isset($this->request[$name]) ? $this->request[$name] : '';
   }
 
@@ -191,7 +251,8 @@ abstract class AbstractBase {
    * @param mixed $name the key of the value to get from the cookie
    * @return mixed the value for the cookie param. Defaults to the empty string if not set.
    */
-  protected function cookie($name) {
+  protected function cookie($name)
+  {
     return isset($this->cookie[$name]) ? $this->cookie[$name] : '';
   }
 
@@ -203,7 +264,8 @@ abstract class AbstractBase {
    * @throws LogicException If the specified action doesn't exist in the action_methods array
    * @throws BadMethodCallException If the action method doesn't exist or isn't an instance method
    */
-  protected function dispatch_action() {
+  protected function dispatch_action()
+  {
     // check that a handler is configure for the current action
     if (empty($this->action_methods[$this->action])) {
       throw new LogicException("No handler method specified for action: {$this->action}!");
@@ -231,9 +293,10 @@ abstract class AbstractBase {
    *
    * @param  string $action The name of the action to be mapper to a method name
    * @param  string $methodName The name of a method name to be used when handling thins action
-   * @return Conifer\AjaxHandler\AbstractBase The current AbstractBase class instance
+   * @return AbstractBase The current AbstractBase class instance
    */
-  protected function map_action($action, $methodName) {
+  protected function map_action($action, $methodName)
+  {
     $this->action_methods[$action] = $methodName;
     return $this;
   }
@@ -243,7 +306,8 @@ abstract class AbstractBase {
    *
    * @param array $cookie The request cookie array
    */
-  private function set_cookie(array $cookie) {
+  private function set_cookie(array $cookie)
+  {
     $this->cookie = $cookie;
   }
 }

--- a/scripts/setup-wordpress.sh
+++ b/scripts/setup-wordpress.sh
@@ -119,8 +119,6 @@ RewriteRule . /index.php [L]
 
 # END WordPress
 EOF
-  fi
-
   wp rewrite flush
 
   echo

--- a/test/unit/AjaxHandler/AjaxHandlerTest.php
+++ b/test/unit/AjaxHandler/AjaxHandlerTest.php
@@ -9,6 +9,8 @@
 
 namespace Conifer\Unit\AjaxHandler;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use WP_Mock;
 
 use Conifer\AjaxHandler\AbstractBase;
@@ -225,6 +227,78 @@ class AjaxHandlerTest extends Base
     $returned = $handler->exposeMap('my_action', 'anInstanceMethod');
 
     $this->assertSame($handler, $returned, 'map_action() should return $this for chaining');
+  }
+
+  // ---------------------------------------------------------------------------
+  // log()
+  // ---------------------------------------------------------------------------
+
+  /**
+   * @dataProvider valid_log_levels
+   */
+  public function test_log_delegates_message_to_configured_logger(string $level)
+  {
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger
+      ->expects($this->once())
+      ->method($level)
+      ->with(self::BEST_BAND);
+
+    new AjaxHandlerInspectable($this->get_request_array(), $logger);
+
+    AjaxHandlerInspectable::log(self::BEST_BAND, $level);
+  }
+
+  public function test_log_converts_stringable_message_before_delegating()
+  {
+    $message = new class implements \Stringable {
+      public function __toString(): string
+      {
+        return AjaxHandlerTest::BEST_BAND;
+      }
+    };
+    $logger = $this->createMock(LoggerInterface::class);
+    $logger
+      ->expects($this->once())
+      ->method(LogLevel::DEBUG)
+      ->with(self::BEST_BAND);
+
+    new AjaxHandlerInspectable($this->get_request_array(), $logger);
+
+    AjaxHandlerInspectable::log($message);
+  }
+
+  public function test_log_throws_when_logger_is_not_configured()
+  {
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Logger is not set. Cannot log message.');
+
+    AjaxHandlerInspectable::log(self::BEST_BAND);
+  }
+
+  public function test_log_throws_when_level_is_invalid()
+  {
+    $logger = $this->createMock(LoggerInterface::class);
+    new AjaxHandlerInspectable($this->get_request_array(), $logger);
+
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('Invalid log level: verbose');
+
+    AjaxHandlerInspectable::log(self::BEST_BAND, 'verbose');
+  }
+
+  public function valid_log_levels(): array
+  {
+    return [
+      'emergency' => [LogLevel::EMERGENCY],
+      'alert'     => [LogLevel::ALERT],
+      'critical'  => [LogLevel::CRITICAL],
+      'error'     => [LogLevel::ERROR],
+      'warning'   => [LogLevel::WARNING],
+      'notice'    => [LogLevel::NOTICE],
+      'info'      => [LogLevel::INFO],
+      'debug'     => [LogLevel::DEBUG],
+    ];
   }
 }
 


### PR DESCRIPTION
**Ticket**: # [248](https://sitecrafting.atlassian.net/browse/GRT-248)

#### Issue

The AbstractBase does not support logging for Ajax requests

#### Solution

Now it does!

I've also updated the docs and changelog.

#### Impact

None, all existing code should continue to work as is. The only change to source code includes optional arguments

#### Usage Changes

Add a not-quite-the-same static log() function to AbstractBase.

#### Considerations

While logging in the AjaxHandler is neat, we could explore a more generic, global solution for logging that could be used in PHP, Twig, and does not require much setup on the developer's part.

#### Testing

I've included updated unit tests for the new logging functionality. PHPStan came back clean, and all tests pass.
