### PR TITLE
Adding utility action functions to AbstractBase

### DIFF
--- a/docs/ajax-handlers.md
+++ b/docs/ajax-handlers.md
@@ -158,6 +158,9 @@ Registers an action for this handler class. By default, the action is available 
 
 Adds the WordPress AJAX hooks for actions registered by this handler class.
 
+### `get_actions()`
+
+Returns the actions registered for this AjaxHandler.
 
 ### `param(mixed $name)`
 

--- a/docs/ajax-handlers.md
+++ b/docs/ajax-handlers.md
@@ -18,10 +18,13 @@ class MyAjaxHandler extends AbstractBase {
 }
 ```
 
-From here, all you need to do is add the appropriate `wp_ajax_{action}` and/or `wp_ajax_nopriv_{action}` actions in your site's [config callback](/site.md#simple-configuration):
+Register the action in the handler class, then add all registered actions in your site's [config callback](/site.md#simple-configuration):
 
 ```PHP
-add_action('wp_ajax_my_action', [MyAjaxHandler::class, 'handle']);
+MyAjaxHandler::register_action('my_action');
+
+// In your config callback:
+MyAjaxHandler::add_actions();
 ```
 
 > ### Info::Use handle(), not execute()
@@ -79,12 +82,15 @@ class RobotAjaxHandler extends AbstractBase {
 }
 ```
 
-Now we add our actions like before, and we're ready to interact with our robot overlords via AJAX calls:
+Register each action in the handler class, then add the hooks in your config callback:
 
 ```PHP
-add_action('wp_ajax_talk_to_robot', [RobotAjaxHandler::class, 'handle']);
-add_action('wp_ajax_ask_robot_to_dance', [RobotAjaxHandler::class, 'handle']);
-add_action('wp_ajax_buy_robot_insurance', [RobotAjaxHandler::class, 'handle']);
+RobotAjaxHandler::register_action('talk_to_robot');
+RobotAjaxHandler::register_action('ask_robot_to_dance');
+RobotAjaxHandler::register_action('buy_robot_insurance');
+
+// In your config callback:
+RobotAjaxHandler::add_actions();
 ```
 
 ## Logging
@@ -141,6 +147,16 @@ Can be used in place of the `handle` method when adding your AJAX action. Uses d
 ### `handle_get()`
 
 Can be used in place of the `handle` method when adding your AJAX action. Uses data only from the [$_GET](http://php.net/manual/en/reserved.variables.get.php) superglobal, which limits your AJAX handler to accepting only GET requests.
+
+
+### `register_action(string $action, bool $include_priv = true, bool $include_no_priv = false)`
+
+Registers an action for this handler class. By default, the action is available only to authenticated users. Set `$include_no_priv` to `true` to also handle unauthenticated requests, or set `$include_priv` to `false` to handle only unauthenticated requests. Call `add_actions()` in your config callback to add the registered hooks.
+
+
+### `add_actions()`
+
+Adds the WordPress AJAX hooks for actions registered by this handler class.
 
 
 ### `param(mixed $name)`

--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -5,4 +5,5 @@
 * Migrate from [Gitbook](https://www.gitbook.com) to [VitePress](https://vitepress.dev).
 
 ## v1.0.5
-* Updated AbstractBase with static logging.
+* Updated `AbstractBase` with static logging.
+* Updated `AbstractBase` with `add_actions()`, `register_action()`, and `get_registered_actions()`

--- a/docs/changelog/2026.md
+++ b/docs/changelog/2026.md
@@ -6,4 +6,4 @@
 
 ## v1.0.5
 * Updated `AbstractBase` with static logging.
-* Updated `AbstractBase` with `add_actions()`, `register_action()`, and `get_registered_actions()`
+* Updated `AbstractBase` with `add_actions()`, `register_action()`, and `get_registered_actions()`.

--- a/lib/Conifer/AjaxHandler/AbstractBase.php
+++ b/lib/Conifer/AjaxHandler/AbstractBase.php
@@ -255,7 +255,7 @@ abstract class AbstractBase
    *
    * @return array The array of registered actions.
    */
-  public static function get_registered_actions(): array
+  public static function get_actions(): array
   {
     return static::$registered_actions[static::class] ?? [];
   }

--- a/lib/Conifer/AjaxHandler/AbstractBase.php
+++ b/lib/Conifer/AjaxHandler/AbstractBase.php
@@ -75,13 +75,10 @@
 namespace Conifer\AjaxHandler;
 
 use BadMethodCallException;
-use InvalidArgumentException;
 use LogicException;
 use ReflectionClass;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
-use RuntimeException;
-use Stringable;
 
 // TODO: Need to add nonce verification to this class and update any related documentation to reflect this requirement
 abstract class AbstractBase
@@ -171,14 +168,14 @@ abstract class AbstractBase
    * This is not a 100% accurate implementation of the LoggerInterface log() function, but it
    * should be good enough to suit our needs
    *
-   * @param string|Stringable $message The message to log
+   * @param string|\Stringable $message The message to log
    * @param string $level The log level to use. Defaults to LogLevel::DEBUG
    * @return void
    *
-   * @throws RuntimeException If the logger is not configured via __construct
-   * @throws InvalidArgumentException If the provided $level is not one of PSR-3's LogLevels
+   * @throws \RuntimeException If the logger is not configured via __construct
+   * @throws \InvalidArgumentException If the provided $level is not one of PSR-3's LogLevels
    */
-  public static function log(string|Stringable $message, string $level = LogLevel::DEBUG): void
+  public static function log(string|\Stringable $message, string $level = LogLevel::DEBUG): void
   {
     // If the logger is not set, we cannot log the message. We should throw a runtime exception.
     if (static::$logger === null) {
@@ -186,7 +183,7 @@ abstract class AbstractBase
     }
 
     // If the message is a Stringable object, we need to convert it to a string.
-    if ($message instanceof Stringable) {
+    if ($message instanceof \Stringable) {
       $message = (string) $message;
     }
 
@@ -219,6 +216,10 @@ abstract class AbstractBase
    */
   public static function register_action(string $action, bool $include_priv = true, bool $include_no_priv = false): void
   {
+    if (empty($action)) {
+      throw new \InvalidArgumentException('Action name cannot be empty.');
+    }
+
     static::$registered_actions[static::class][$action] = [
       'include_priv'    => $include_priv,
       'include_no_priv' => $include_no_priv,

--- a/lib/Conifer/AjaxHandler/AbstractBase.php
+++ b/lib/Conifer/AjaxHandler/AbstractBase.php
@@ -235,10 +235,16 @@ abstract class AbstractBase
   {
     foreach (static::$registered_actions[static::class] ?? [] as $action => $options) {
       if ($options['include_priv']) {
+        if (false !== has_action("wp_ajax_{$action}")) {
+          throw new \LogicException("Action '{$action}' is already registered with WordPress. Cannot register it again for handler class " . static::class);
+        }
         add_action("wp_ajax_{$action}", [static::class, 'handle']);
       }
 
       if ($options['include_no_priv']) {
+        if (false !== has_action("wp_ajax_nopriv_{$action}")) {
+          throw new \LogicException("Action '{$action}' is already registered with WordPress. Cannot register it again for handler class " . static::class);
+        }
         add_action("wp_ajax_nopriv_{$action}", [static::class, 'handle']);
       }
     }

--- a/lib/Conifer/AjaxHandler/AbstractBase.php
+++ b/lib/Conifer/AjaxHandler/AbstractBase.php
@@ -119,6 +119,13 @@ abstract class AbstractBase
   protected static ?LoggerInterface $logger = null;
 
   /**
+   * Registered AJAX actions, keyed by handler class and action name.
+   *
+   * @var array<string, array<string, array{include_priv: bool, include_no_priv: bool}>>
+   */
+  protected static array $registered_actions = [];
+
+  /**
    * Abstract method used to define the functionality when handling an AJAX request.
    * Should return an array to be encoded in the response.
    *
@@ -198,6 +205,52 @@ abstract class AbstractBase
       default:
         throw new \InvalidArgumentException("Invalid log level: {$level}");
     }
+  }
+
+  /**
+   * Register an AJAX action for this handler class.
+   *
+   * Call add_actions() in the site's configuration callback to add the registered hooks.
+   *
+   * @param string $action The AJAX action name.
+   * @param bool $include_priv Whether to handle requests from authenticated users.
+   * @param bool $include_no_priv Whether to handle requests from unauthenticated users.
+   * @return void
+   */
+  public static function register_action(string $action, bool $include_priv = true, bool $include_no_priv = false): void
+  {
+    static::$registered_actions[static::class][$action] = [
+      'include_priv'    => $include_priv,
+      'include_no_priv' => $include_no_priv,
+    ];
+  }
+
+  /**
+   * Add WordPress hooks for all actions registered by this handler class.
+   *
+   * @return void
+   */
+  public static function add_actions(): void
+  {
+    foreach (static::$registered_actions[static::class] ?? [] as $action => $options) {
+      if ($options['include_priv']) {
+        add_action("wp_ajax_{$action}", [static::class, 'handle']);
+      }
+
+      if ($options['include_no_priv']) {
+        add_action("wp_ajax_nopriv_{$action}", [static::class, 'handle']);
+      }
+    }
+  }
+
+  /**
+   * Return the actions registered to this AjaxHandler
+   *
+   * @return array The array of registered actions.
+   */
+  public static function get_registered_actions(): array
+  {
+    return static::$registered_actions[static::class] ?? [];
   }
 
   /*

--- a/test/unit/AjaxHandler/AjaxHandlerTest.php
+++ b/test/unit/AjaxHandler/AjaxHandlerTest.php
@@ -230,6 +230,82 @@ class AjaxHandlerTest extends Base
   }
 
   // ---------------------------------------------------------------------------
+  // register_action() / add_actions()
+  // ---------------------------------------------------------------------------
+
+  public function test_add_actions_registers_authenticated_hook_by_default()
+  {
+    AjaxHandlerInspectable::clearRegisteredActions();
+    AjaxHandlerInspectable::register_action('inspect');
+
+    WP_Mock::expectActionAdded('wp_ajax_inspect', [AjaxHandlerInspectable::class, 'handle']);
+
+    AjaxHandlerInspectable::add_actions();
+
+    $this->assertArrayHasKey('inspect', AjaxHandlerInspectable::get_registered_actions());
+    $this->assertTrue(AjaxHandlerInspectable::get_registered_actions()['inspect']['include_priv']);
+    $this->assertFalse(AjaxHandlerInspectable::get_registered_actions()['inspect']['include_no_priv']);
+  }
+
+  public function test_add_actions_registers_both_hooks_when_requested()
+  {
+    AjaxHandlerInspectable::clearRegisteredActions();
+    AjaxHandlerInspectable::register_action('inspect', true, true);
+
+    WP_Mock::expectActionAdded('wp_ajax_inspect', [AjaxHandlerInspectable::class, 'handle']);
+    WP_Mock::expectActionAdded('wp_ajax_nopriv_inspect', [AjaxHandlerInspectable::class, 'handle']);
+
+    AjaxHandlerInspectable::add_actions();
+
+    $this->assertArrayHasKey('inspect', AjaxHandlerInspectable::get_registered_actions());
+    $this->assertTrue(AjaxHandlerInspectable::get_registered_actions()['inspect']['include_priv']);
+    $this->assertTrue(AjaxHandlerInspectable::get_registered_actions()['inspect']['include_no_priv']);
+  }
+
+  public function test_add_actions_can_register_unauthenticated_hook_only()
+  {
+    AjaxHandlerInspectable::clearRegisteredActions();
+    AjaxHandlerInspectable::register_action('inspect', false, true);
+
+    WP_Mock::expectActionAdded('wp_ajax_nopriv_inspect', [AjaxHandlerInspectable::class, 'handle']);
+
+    AjaxHandlerInspectable::add_actions();
+
+    $this->assertArrayHasKey('inspect', AjaxHandlerInspectable::get_registered_actions());
+    $this->assertFalse(AjaxHandlerInspectable::get_registered_actions()['inspect']['include_priv']);
+  }
+
+  public function test_register_action_replaces_existing_privilege_options()
+  {
+    AjaxHandlerInspectable::clearRegisteredActions();
+    AjaxHandlerInspectable::register_action('inspect');
+    AjaxHandlerInspectable::register_action('inspect', false, true);
+
+    WP_Mock::expectActionAdded('wp_ajax_nopriv_inspect', [AjaxHandlerInspectable::class, 'handle']);
+
+    AjaxHandlerInspectable::add_actions();
+
+    $this->assertArrayHasKey('inspect', AjaxHandlerInspectable::get_registered_actions());
+    $this->assertFalse(AjaxHandlerInspectable::get_registered_actions()['inspect']['include_priv']);
+  }
+
+  public function test_add_actions_only_uses_actions_registered_by_its_class()
+  {
+    AjaxHandlerInspectable::clearRegisteredActions();
+    AlternateAjaxHandlerInspectable::clearRegisteredActions();
+    AjaxHandlerInspectable::register_action('inspect');
+    AlternateAjaxHandlerInspectable::register_action('alternate');
+
+    WP_Mock::expectActionAdded('wp_ajax_inspect', [AjaxHandlerInspectable::class, 'handle']);
+
+    AjaxHandlerInspectable::add_actions();
+
+    $this->assertArrayHasKey('alternate', AlternateAjaxHandlerInspectable::get_registered_actions());
+    $this->assertTrue(AlternateAjaxHandlerInspectable::get_registered_actions()['alternate']['include_priv']);
+    $this->assertFalse(AlternateAjaxHandlerInspectable::get_registered_actions()['alternate']['include_no_priv']);
+  }
+
+  // ---------------------------------------------------------------------------
   // log()
   // ---------------------------------------------------------------------------
 
@@ -347,6 +423,11 @@ class AjaxHandlerInspectable extends AbstractBase
     return $this;
   }
 
+  public static function clearRegisteredActions(): void
+  {
+    unset(self::$registered_actions[static::class]);
+  }
+
   /** Used to verify the success-path of dispatch_action(). */
   protected function anInstanceMethod(): array
   {
@@ -359,3 +440,5 @@ class AjaxHandlerInspectable extends AbstractBase
     return ['dispatched_by' => 'aStaticMethod'];
   }
 }
+
+class AlternateAjaxHandlerInspectable extends AjaxHandlerInspectable {}

--- a/test/unit/AjaxHandler/AjaxHandlerTest.php
+++ b/test/unit/AjaxHandler/AjaxHandlerTest.php
@@ -246,9 +246,9 @@ class AjaxHandlerTest extends Base
 
     AjaxHandlerInspectable::add_actions();
 
-    $this->assertArrayHasKey('inspect', AjaxHandlerInspectable::get_registered_actions());
-    $this->assertTrue(AjaxHandlerInspectable::get_registered_actions()['inspect']['include_priv']);
-    $this->assertFalse(AjaxHandlerInspectable::get_registered_actions()['inspect']['include_no_priv']);
+    $this->assertArrayHasKey('inspect', AjaxHandlerInspectable::get_actions());
+    $this->assertTrue(AjaxHandlerInspectable::get_actions()['inspect']['include_priv']);
+    $this->assertFalse(AjaxHandlerInspectable::get_actions()['inspect']['include_no_priv']);
   }
 
   public function test_add_actions_registers_both_hooks_when_requested()
@@ -261,9 +261,9 @@ class AjaxHandlerTest extends Base
 
     AjaxHandlerInspectable::add_actions();
 
-    $this->assertArrayHasKey('inspect', AjaxHandlerInspectable::get_registered_actions());
-    $this->assertTrue(AjaxHandlerInspectable::get_registered_actions()['inspect']['include_priv']);
-    $this->assertTrue(AjaxHandlerInspectable::get_registered_actions()['inspect']['include_no_priv']);
+    $this->assertArrayHasKey('inspect', AjaxHandlerInspectable::get_actions());
+    $this->assertTrue(AjaxHandlerInspectable::get_actions()['inspect']['include_priv']);
+    $this->assertTrue(AjaxHandlerInspectable::get_actions()['inspect']['include_no_priv']);
   }
 
   public function test_add_actions_can_register_unauthenticated_hook_only()
@@ -275,8 +275,8 @@ class AjaxHandlerTest extends Base
 
     AjaxHandlerInspectable::add_actions();
 
-    $this->assertArrayHasKey('inspect', AjaxHandlerInspectable::get_registered_actions());
-    $this->assertFalse(AjaxHandlerInspectable::get_registered_actions()['inspect']['include_priv']);
+    $this->assertArrayHasKey('inspect', AjaxHandlerInspectable::get_actions());
+    $this->assertFalse(AjaxHandlerInspectable::get_actions()['inspect']['include_priv']);
   }
 
   public function test_register_action_replaces_existing_privilege_options()
@@ -289,8 +289,8 @@ class AjaxHandlerTest extends Base
 
     AjaxHandlerInspectable::add_actions();
 
-    $this->assertArrayHasKey('inspect', AjaxHandlerInspectable::get_registered_actions());
-    $this->assertFalse(AjaxHandlerInspectable::get_registered_actions()['inspect']['include_priv']);
+    $this->assertArrayHasKey('inspect', AjaxHandlerInspectable::get_actions());
+    $this->assertFalse(AjaxHandlerInspectable::get_actions()['inspect']['include_priv']);
   }
 
   public function test_add_actions_only_uses_actions_registered_by_its_class()
@@ -304,9 +304,9 @@ class AjaxHandlerTest extends Base
 
     AjaxHandlerInspectable::add_actions();
 
-    $this->assertArrayHasKey('alternate', AlternateAjaxHandlerInspectable::get_registered_actions());
-    $this->assertTrue(AlternateAjaxHandlerInspectable::get_registered_actions()['alternate']['include_priv']);
-    $this->assertFalse(AlternateAjaxHandlerInspectable::get_registered_actions()['alternate']['include_no_priv']);
+    $this->assertArrayHasKey('alternate', AlternateAjaxHandlerInspectable::get_actions());
+    $this->assertTrue(AlternateAjaxHandlerInspectable::get_actions()['alternate']['include_priv']);
+    $this->assertFalse(AlternateAjaxHandlerInspectable::get_actions()['alternate']['include_no_priv']);
   }
 
   // ---------------------------------------------------------------------------

--- a/test/unit/AjaxHandler/AjaxHandlerTest.php
+++ b/test/unit/AjaxHandler/AjaxHandlerTest.php
@@ -29,6 +29,10 @@ class AjaxHandlerTest extends Base
   {
     parent::setUp();
 
+    WP_Mock::userFunction('has_action', [
+      'return' => false,
+    ]);
+
     // Mock the abstract base AJAX handler class so we can test against it
     $ajaxHanderStub = $this->getMockForAbstractClass(AbstractBase::class, [$this->get_request_array()]);
 


### PR DESCRIPTION
**Ticket**: # [266](https://sitecrafting.atlassian.net/browse/GRT-266)

#### Issue

AbstractBase does not provide any way to register actions

#### Solution

Now it does!

#### Impact

Minimal, this should not affect any existing code. This update only extends functionality.

#### Testing

This update passed unit tests and PHPStan analysis
